### PR TITLE
Add script to load and tag new cqf ruler image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ synthea
 connectathon
 .cqf-ruler
 .seed-cqf-ruler
+.seed-cqf-ruler-no-vs
 .setup-cqf-ruler
 *.csv

--- a/EXM_104/Makefile
+++ b/EXM_104/Makefile
@@ -18,8 +18,8 @@ connectathon:
 
 .seed-cqf-ruler:
 	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-dstu3/fhir/Measure \
+	curl -X PUT \
+  http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-exm104-FHIR3 \
   -H 'Content-Type: application/json' \
 	-d @connectathon/fhir3/resources/measure/measure-EXM104_FHIR3-8.1.000.json
 	curl -X POST \
@@ -44,6 +44,30 @@ connectathon:
 	-d @connectathon/fhir3/resources/valuesets/valuesets-EXM104_FHIR3-8.1.000.json
 	touch .seed-cqf-ruler
 
+.seed-cqf-ruler-no-vs:
+	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
+	curl -X PUT \
+  http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-exm104-FHIR3 \
+  -H 'Content-Type: application/json' \
+	-d @connectathon/fhir3/resources/measure/measure-EXM104_FHIR3-8.1.000.json
+	curl -X POST \
+  http://localhost:8080/cqf-ruler-dstu3/fhir \
+  -H 'Content-Type: application/json' \
+	-d @connectathon/fhir3/resources/library/all-libraries-bundle.json
+	curl -X POST \
+  http://localhost:8080/cqf-ruler-dstu3/fhir/Library \
+  -H 'Content-Type: application/json' \
+	-d @connectathon/fhir3/resources/library/library-EXM104_FHIR3-8.1.000.json
+	curl -X POST \
+  http://localhost:8080/cqf-ruler-dstu3/fhir/Library \
+  -H 'Content-Type: application/json' \
+	-d @connectathon/fhir3/resources/library/library-TJC_Overall_FHIR3-3.6.000.json
+		curl -X POST \
+  http://localhost:8080/cqf-ruler-dstu3/fhir/Library \
+  -H 'Content-Type: application/json' \
+	-d @connectathon/fhir3/resources/library/library-MATGlobalCommonFunctions_FHIR3-4.0.000.json
+	touch .seed-cqf-ruler-no-vs
+
 synthea:
 	git clone --single-branch --branch abacus --depth 1 https://github.com/projecttacoma/synthea.git
 
@@ -53,10 +77,10 @@ generate-patients:
 
 CQL_FILE := EXM104_FHIR3-8.1.000.cql
 calculate-patients:
-	calculate-bundles -d ./synthea/output/fhir_stu3 -c $(CQL_FILE) -u http://localhost:8080/cqf-ruler-dstu3/fhir -s "2018-01-01" -e "2018-12-31"
+	calculate-bundles -d ./synthea/output/fhir_stu3 -c $(CQL_FILE) -u http://localhost:8080/cqf-ruler-dstu3/fhir -s "2018-01-01" -e "2018-12-31" -m measure-exm104-FHIR3
 
 clean:
 	-docker stop cqf-ruler
-	-rm -rf synthea output connectathon .cqf-ruler .seed-cqf-ruler .generate-patients .calculate-patients .setup-cqf-ruler
+	-rm -rf synthea output connectathon .cqf-ruler .seed-cqf-ruler .seed-cqf-ruler-no-vs .generate-patients .calculate-patients .setup-cqf-ruler
 
 .PHONY: all clean info

--- a/EXM_105/Makefile
+++ b/EXM_105/Makefile
@@ -20,6 +20,7 @@ connectathon:
   http://localhost:8080/cqf-ruler-dstu3/fhir \
   -H 'Content-Type: application/json' \
 	-d @connectathon/fhir3/bundles/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-bundle.json
+	touch .seed-cqf-ruler
 
 .seed-cqf-ruler-no-vs:
 	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
@@ -35,6 +36,7 @@ connectathon:
   http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM105-FHIR3-8.0.000 \
   -H 'Content-Type: application/json' \
 	-d @connectathon/fhir3/bundles/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/measure-EXM105_FHIR3-8.0.000.json
+	touch .seed-cqf-ruler-no-vs
 
 synthea:
 	git clone --single-branch --branch abacus --depth 1 https://github.com/projecttacoma/synthea.git
@@ -49,6 +51,6 @@ calculate-patients:
 
 clean:
 	-docker stop cqf-ruler
-	-rm -rf synthea output connectathon .cqf-ruler .seed-cqf-ruler .generate-patients .calculate-patients .setup-cqf-ruler
+	-rm -rf synthea output connectathon .cqf-ruler .seed-cqf-ruler .seed-cqf-ruler-no-vs .generate-patients .calculate-patients .setup-cqf-ruler
 
 .PHONY: all clean info

--- a/EXM_105/Makefile
+++ b/EXM_105/Makefile
@@ -21,6 +21,21 @@ connectathon:
   -H 'Content-Type: application/json' \
 	-d @connectathon/fhir3/bundles/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-bundle.json
 
+.seed-cqf-ruler-no-vs:
+	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
+	curl -X POST \
+  http://localhost:8080/cqf-ruler-dstu3/fhir \
+  -H 'Content-Type: application/json' \
+	-d @connectathon/fhir3/bundles/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/library-deps-EXM105_FHIR3-8.0.000-bundle.json
+	curl -X PUT \
+  http://localhost:8080/cqf-ruler-dstu3/fhir/Library/library-EXM105-FHIR3-8.0.000 \
+  -H 'Content-Type: application/json' \
+	-d @connectathon/fhir3/bundles/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/library-EXM105_FHIR3-8.0.000.json
+	curl -X PUT \
+  http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM105-FHIR3-8.0.000 \
+  -H 'Content-Type: application/json' \
+	-d @connectathon/fhir3/bundles/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/measure-EXM105_FHIR3-8.0.000.json
+
 synthea:
 	git clone --single-branch --branch abacus --depth 1 https://github.com/projecttacoma/synthea.git
 
@@ -30,7 +45,7 @@ generate-patients:
 
 CQL_FILE := connectathon/fhir3/bundles/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/EXM105_FHIR3-8.0.000.cql
 calculate-patients:
-	calculate-bundles -d ./synthea/output/fhir_stu3 -c $(CQL_FILE) -u http://localhost:8080/cqf-ruler-dstu3/fhir
+	calculate-bundles -d ./synthea/output/fhir_stu3 -c $(CQL_FILE) -u http://localhost:8080/cqf-ruler-dstu3/fhir --measure-id measure-EXM105-FHIR3-8.0.000
 
 clean:
 	-docker stop cqf-ruler

--- a/EXM_124/Makefile
+++ b/EXM_124/Makefile
@@ -18,8 +18,8 @@ connectathon:
 
 .seed-cqf-ruler:
 	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-dstu3/fhir/Measure \
+	curl -X PUT \
+  http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-exm124-FHIR3 \
   -H 'Content-Type: application/json' \
 	-d @connectathon/fhir3/resources/measure/measure-EXM124_FHIR3-7.2.000.json
 	curl -X POST \
@@ -32,6 +32,18 @@ connectathon:
 	-d @connectathon/fhir3/resources/valuesets/valuesets-EXM124_FHIR3-7.2.000.json
 	touch .seed-cqf-ruler
 
+.seed-cqf-ruler-no-vs:
+	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
+	curl -X PUT \
+  http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-exm124-FHIR3 \
+  -H 'Content-Type: application/json' \
+	-d @connectathon/fhir3/resources/measure/measure-EXM124_FHIR3-7.2.000.json
+	curl -X POST \
+  http://localhost:8080/cqf-ruler-dstu3/fhir \
+  -H 'Content-Type: application/json' \
+	-d @connectathon/fhir3/resources/library/all-libraries-bundle.json
+	touch .seed-cqf-ruler-no-vs
+
 synthea:
 	git clone --single-branch --branch abacus https://github.com/projecttacoma/synthea.git
 
@@ -41,11 +53,11 @@ generate-patients:
 
 CQL_FILE := EXM124_FHIR3-7.2.000.cql
 calculate-patients:
-	calculate-bundles -d ./synthea/output/fhir_stu3 -c $(CQL_FILE) -u http://localhost:8080/cqf-ruler-dstu3/fhir -s "2018-01-01" -e "2018-12-31"
+	calculate-bundles -d ./synthea/output/fhir_stu3 -c $(CQL_FILE) -u http://localhost:8080/cqf-ruler-dstu3/fhir -s "2018-01-01" -e "2018-12-31" -m measure-exm124-FHIR3
 
 clean:
 	-docker stop cqf-ruler
-	-rm -rf synthea output connectathon .cqf-ruler .seed-cqf-ruler .generate-patients .calculate-patients .setup-cqf-ruler
+	-rm -rf synthea output connectathon .cqf-ruler .seed-cqf-ruler .seed-cqf-ruler-no-vs .generate-patients .calculate-patients .setup-cqf-ruler
 
 .PHONY: all clean info
 .SECONDARY: main-build

--- a/EXM_125/Makefile
+++ b/EXM_125/Makefile
@@ -18,8 +18,8 @@ connectathon:
 
 .seed-cqf-ruler:
 	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-dstu3/fhir/Measure \
+	curl -X PUT \
+  http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-exm125-FHIR3 \
   -H 'Content-Type: application/json' \
 	-d @connectathon/fhir3/resources/measure/measure-EXM125_FHIR3-7.2.000.json
 	curl -X POST \
@@ -32,6 +32,18 @@ connectathon:
 	-d @connectathon/fhir3/resources/valuesets/valuesets-EXM125_FHIR3-7.2.000.json
 	touch .seed-cqf-ruler
 
+.seed-cqf-ruler-no-vs:
+	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
+	curl -X PUT \
+  http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-exm125-FHIR3 \
+  -H 'Content-Type: application/json' \
+	-d @connectathon/fhir3/resources/measure/measure-EXM125_FHIR3-7.2.000.json
+	curl -X POST \
+  http://localhost:8080/cqf-ruler-dstu3/fhir \
+  -H 'Content-Type: application/json' \
+	-d @connectathon/fhir3/resources/library/all-libraries-bundle.json
+	touch .seed-cqf-ruler-no-vs
+
 synthea:
 	git clone --single-branch --branch abacus https://github.com/projecttacoma/synthea.git
 
@@ -41,10 +53,10 @@ generate-patients:
 
 CQL_FILE := EXM125_FHIR3-7.2.000.cql
 calculate-patients:
-	calculate-bundles -d ./synthea/output/fhir_stu3 -c $(CQL_FILE) -u http://localhost:8080/cqf-ruler-dstu3/fhir
+	calculate-bundles -d ./synthea/output/fhir_stu3 -c $(CQL_FILE) -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-exm125-FHIR3
 
 clean:
 	-docker stop cqf-ruler
-	-rm -rf synthea output connectathon .cqf-ruler .seed-cqf-ruler .generate-patients .calculate-patients .setup-cqf-ruler
+	-rm -rf synthea output connectathon .cqf-ruler .seed-cqf-ruler .seed-cqf-ruler-no-vs .generate-patients .calculate-patients .setup-cqf-ruler
 
 .PHONY: all clean info

--- a/EXM_130/Makefile
+++ b/EXM_130/Makefile
@@ -18,6 +18,10 @@ connectathon:
 
 .seed-cqf-ruler:
 	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
+	curl -X PUT \
+  http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-exm130-FHIR3 \
+  -H 'Content-Type: application/json' \
+	-d @connectathon/fhir3/resources/measure/measure-EXM130_FHIR3-7.2.000.json
 	curl -X POST \
   http://localhost:8080/cqf-ruler-dstu3/fhir/ \
   -H 'Content-Type: application/json' \
@@ -30,6 +34,23 @@ connectathon:
   http://localhost:8080/cqf-ruler-dstu3/fhir \
   -H 'Content-Type: application/json' \
 	-d @connectathon/fhir3/resources/valuesets/valuesets-EXM130_FHIR3-7.2.000.json
+	touch .seed-cqf-ruler
+
+.seed-cqf-ruler-no-vs:
+	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
+	curl -X PUT \
+  http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-exm130-FHIR3 \
+  -H 'Content-Type: application/json' \
+	-d @connectathon/fhir3/resources/measure/measure-EXM130_FHIR3-7.2.000.json
+	curl -X POST \
+  http://localhost:8080/cqf-ruler-dstu3/fhir/ \
+  -H 'Content-Type: application/json' \
+	-d @EXM_130_bundle.json
+	curl -X POST \
+  http://localhost:8080/cqf-ruler-dstu3/fhir \
+  -H 'Content-Type: application/json' \
+	-d @connectathon/fhir3/resources/library/all-libraries-bundle.json
+	touch .seed-cqf-ruler-no-vs
 
 synthea:
 	git clone --single-branch --branch abacus https://github.com/projecttacoma/synthea.git
@@ -40,10 +61,10 @@ generate-patients:
 
 CQL_FILE := EXM130_FHIR3.cql
 calculate-patients:
-	calculate-bundles -d ./synthea/output/fhir_stu3 -c $(CQL_FILE) -u http://localhost:8080/cqf-ruler-dstu3/fhir
+	calculate-bundles -d ./synthea/output/fhir_stu3 -c $(CQL_FILE) -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-exm130-FHIR3
 
 clean:
 	-docker stop cqf-ruler
-	-rm -rf synthea output connectathon .cqf-ruler .seed-cqf-ruler .generate-patients .calculate-patients .setup-cqf-ruler
+	-rm -rf synthea output connectathon .cqf-ruler .seed-cqf-ruler .seed-cqf-ruler-no-vs .generate-patients .calculate-patients .setup-cqf-ruler
 
 .PHONY: all clean info

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ info:
 	./load-cqf-ruler.sh $(MEASURE_DIR)
 
 .restart-cqf-ruler:
-	docker stop cqf-ruler || true && docker run --name cqf-ruler --rm -dit -p 8080:8080 contentgroup/cqf-ruler:develop
+	-docker stop cqf-ruler
+	docker run --name cqf-ruler --rm -dit -p 8080:8080 contentgroup/cqf-ruler:develop
 
 .update-cqf-ruler-image: .seed-cqf-ruler-no-vs .run-load-script
 	docker tag $(shell docker commit cqf-ruler) tacoma/cqf-ruler-preloaded:$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
-all: .restart-cqf-ruler .run-load-script .update-cqf-ruler-image
+all: .restart-cqf-ruler .update-cqf-ruler-image
 
 info:
 	$(info usage: `make MEASURE_DIR=/path/to/measure/dir VERSION=x.y.z)
 
 .seed-cqf-ruler-no-vs:
-	cd $(MEASURE_DIR)
-	make connectathon .seed-cqf-ruler-no-vs
+	make -C $(MEASURE_DIR) connectathon .seed-cqf-ruler-no-vs
+	touch .seed-cqf-ruler-no-vs
 
 .run-load-script:
 	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
@@ -14,11 +14,12 @@ info:
 .restart-cqf-ruler:
 	docker stop cqf-ruler || true && docker run --name cqf-ruler --rm -dit -p 8080:8080 contentgroup/cqf-ruler:develop
 
-.update-cqf-ruler-image:
+.update-cqf-ruler-image: .seed-cqf-ruler-no-vs .run-load-script
 	docker tag $(shell docker commit cqf-ruler) tacoma/cqf-ruler-preloaded:$(VERSION)
 	docker push tacoma/cqf-ruler-preloaded:$(VERSION)
 
 clean:
-	docker stop cqf-ruler
+	-docker stop cqf-ruler
+	-rm -rf .seed-cqf-ruler-no-vs
 
 .PHONY: all clean info

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+all: .restart-cqf-ruler .run-load-script .update-cqf-ruler-image
+
+info:
+	$(info usage: `make MEASURE_DIR=/path/to/measure/dir VERSION=x.y.z)
+
+.seed-cqf-ruler-no-vs:
+	cd $(MEASURE_DIR)
+	make connectathon .seed-cqf-ruler-no-vs
+
+.run-load-script:
+	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
+	./load-cqf-ruler.sh $(MEASURE_DIR)
+
+.restart-cqf-ruler:
+	docker stop cqf-ruler || true && docker run --name cqf-ruler --rm -dit -p 8080:8080 contentgroup/cqf-ruler:develop
+
+.update-cqf-ruler-image:
+	docker tag $(shell docker commit cqf-ruler) tacoma/cqf-ruler-preloaded:$(VERSION)
+	docker push tacoma/cqf-ruler-preloaded:$(VERSION)
+
+clean:
+	docker stop cqf-ruler
+
+.PHONY: all clean info

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,7 @@ info:
 	docker run --name cqf-ruler --rm -dit -p 8080:8080 contentgroup/cqf-ruler:develop
 
 .update-cqf-ruler-image: .seed-cqf-ruler-no-vs .run-load-script
-	docker tag $(shell docker commit cqf-ruler) tacoma/cqf-ruler-preloaded:$(VERSION)
-	docker push tacoma/cqf-ruler-preloaded:$(VERSION)
+	./release-docker-image.sh $(VERSION)
 
 clean:
 	-docker stop cqf-ruler

--- a/load-cqf-ruler.sh
+++ b/load-cqf-ruler.sh
@@ -8,7 +8,7 @@ fi
 
 cd $1
 BASE_URL="http://localhost:8080/cqf-ruler-dstu3/fhir"
-OUTPUT_DIR="output/$(ls -t 'output')"
+OUTPUT_DIR="output/$(ls -t 'output' | head -1)"
 
 check_success() {
   if [ $? -ne 0 ]

--- a/load-cqf-ruler.sh
+++ b/load-cqf-ruler.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+if [ -z "$1" ]
+then
+    echo 'Usage: ./load-cqf-ruler.sh <measure-directory>';
+    exit 1;
+fi
+
+cd $1
+BASE_URL="http://localhost:8080/cqf-ruler-dstu3/fhir"
+OUTPUT_DIR="output/$(ls -t 'output')"
+
+check_success() {
+  if [ $? -ne 0 ]
+  then
+      echo "Error.. aborting"
+      exit 1
+  fi
+}
+
+echo "Using directory $OUTPUT_DIR"
+echo 'Posting MeasureReport'
+curl -s -X POST -H "Content-Type: application/json" --data @$OUTPUT_DIR/measure-report.json "$BASE_URL/MeasureReport" > /dev/null
+check_success
+
+echo 'Posting ipop patients for:' "$OUTPUT_DIR"
+for bundle in ./$OUTPUT_DIR/ipop/*.json;
+do
+    echo 'Posting bundle': "$bundle";
+    curl -s -X POST -H "Content-Type: application/json" --data @$bundle $BASE_URL > /dev/null
+    check_success
+done
+
+echo 'Posting numerator patients for:' "$OUTPUT_DIR"
+for bundle in ./$OUTPUT_DIR/numerator/*.json;
+do
+    echo 'Posting bundle': "$bundle";
+    curl -s -X POST -H "Content-Type: application/json" --data @$bundle $BASE_URL > /dev/null
+    check_success
+done
+
+echo 'Posting denominator patients for:' "$OUTPUT_DIR"
+for bundle in ./$OUTPUT_DIR/denominator/*.json;
+do
+    echo 'Posting bundle': "$bundle";
+    curl -s -X POST -H "Content-Type: application/json" --data @$bundle $BASE_URL > /dev/null
+    check_success
+done
+
+echo 'Done'
+

--- a/release-docker-image.sh
+++ b/release-docker-image.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [ -z "$1" ]
+then
+    echo 'Usage: ./release-docker-image.sh <docker-tag-version>';
+    exit 1;
+fi
+
+# 1 if grep found a match (no ValueSets), 0 otherwise
+VSET_SEARCH_MATCH=`curl -s http://localhost:8080/cqf-ruler-dstu3/fhir/ValueSet | grep -wc "\"total\":\s0"`
+if [ $VSET_SEARCH_MATCH -eq 1 ]
+then
+    docker tag `docker commit cqf-ruler` tacoma/cqf-ruler-preloaded:$1
+    echo "Successfully tagged tacoma/cqf-ruler-preloaded:$1"
+    docker push tacoma/cqf-ruler-preloaded:$1
+    echo "Successfully pushed tacoma/cqf-ruler-preloaded:$1 to Dockerhub"
+else
+    echo "Cannot push image with ValueSets, please remove them before continuing"
+    exit 1
+fi
+


### PR DESCRIPTION
# Summary

Add ability to load a fresh cqf-ruler with measure and patient data that is outputted from `fhir-bundle-calculator` (no valuesets).

## New behavior

Ability to run a script from the root directory and specify measure/docker version to tag

## Code changes

* Bash script to load cqf ruler with `MeasureReport` and patient data
* Root Makefile to run above script and tag/release new docker image.
* Added option to EXM105's makefile to use the measure report generation flag added in https://github.com/projecttacoma/fhir-bundle-calculator/pull/10

# Testing guidance

1) Run ye olde `make` of an individual measure's `Makefile` this will generate `output` in that measure's directory, which needs to be present for the script I added.
  * If #2 is not merged before this, then just use EXM105, as it is the only one whose files live here now
2) In the root directory of this repo, run `make MEASURE_DIR=/path/to/measure VERSION=x.y.z`
  * This will take the most recent output from 1), load a fresh cqf-ruler image with the patient and measure data, tag it with the version specified, and push it to dockerhub. 
  * **NOTE**: If you just want to test without pushing, just comment out line 19 of the `Makefile`

**Important**: The measure's Makefile now depends on https://github.com/projecttacoma/fhir-bundle-calculator/pull/10, as it expects a `MeasureReport` resource to be there. Options to get the most up to date are either set up an `npm link` with your `fhir-bundle-calculator` code on the branch `measurereport-generation` or replace `calculate-bundles` with `node /path/to/fhir-bundle/calculator/src/cli.js` while testing until the referenced PR is merged.

Godspeed.
