### PR TITLE
Refactor the Makefiles to be more DRY/simple.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 output
 synthea
 connectathon
-.cqf-ruler
-.seed-cqf-ruler*
-.seed-cqf-ruler-no-vs*
+.new-cqf-ruler
+.seed-measures*
+.seed-vs*
 .setup-cqf-ruler*
 *.csv
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 output
 synthea
 connectathon
+stu3
+r4
 .new-cqf-ruler
 .seed-measures*
 .seed-vs*

--- a/EXM_104/Makefile
+++ b/EXM_104/Makefile
@@ -1,125 +1,29 @@
-all: info .setup-cqf-ruler synthea generate-patients calculate-patients
+all r4: info generate-patients-r4 calculate-patients-r4
 
-r4: info .setup-cqf-ruler-r4 synthea generate-patients-r4 calculate-patients-r4
+stu3: info generate-patients-stu3 calculate-patients-stu3
 
 info:
-	$(info `make` will cache the cqf-ruler, connectathon, and synythea setups, but repeat patient generation and calculation.)
-	$(info To repeat all steps, do `make clean; make`)
-
-.setup-cqf-ruler: .cqf-ruler connectathon .seed-cqf-ruler
-	touch .setup-cqf-ruler
-
-.setup-cqf-ruler-r4: .cqf-ruler connectathon .seed-cqf-ruler-r4
-	touch .setup-cqf-ruler-r4:
-
-.cqf-ruler:
-	docker run --name cqf-ruler --rm -dit -p 8080:8080 contentgroup/cqf-ruler
-	touch .cqf-ruler
-
-connectathon:
-	git clone https://github.com/DBCG/connectathon.git
-
-.seed-cqf-ruler:
-	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
-	curl -X PUT \
-  http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM104-FHIR3-8.1.000 \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/resources/measure/measure-EXM104_FHIR3-8.1.000.json
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-dstu3/fhir \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/bundles/EXM104_FHIR3-8.1.000/EXM104_FHIR3-8.1.000-bundle.json
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-dstu3/fhir/Library \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/resources/library/library-EXM104_FHIR3-8.1.000.json
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-dstu3/fhir/Library \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/resources/library/library-TJCOverall_FHIR3-3.6.000.json
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-dstu3/fhir/Library \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/resources/library/library-MATGlobalCommonFunctions_FHIR3-4.0.000.json
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-dstu3/fhir \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/resources/valuesets/valuesets-EXM104_FHIR3-8.1.000-bundle.json
-	touch .seed-cqf-ruler
-
-.seed-cqf-ruler-no-vs:
-	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
-	curl -X PUT \
-  http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM104-FHIR3-8.1.000 \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/resources/measure/measure-EXM104_FHIR3-8.1.000.json
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-dstu3/fhir \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/bundles/EXM104_FHIR3-8.1.000/EXM104_FHIR3-8.1.000-bundle.json
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-dstu3/fhir/Library \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/resources/library/library-EXM104_FHIR3-8.1.000.json
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-dstu3/fhir/Library \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/resources/library/library-TJCOverall_FHIR3-3.6.000.json
-		curl -X POST \
-  http://localhost:8080/cqf-ruler-dstu3/fhir/Library \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/resources/library/library-MATGlobalCommonFunctions_FHIR3-4.0.000.json
-	touch .seed-cqf-ruler-no-vs
-
-.seed-cqf-ruler-r4:
-	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-r4`; do printf '.'; sleep 5; done
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-r4/fhir/ \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir4/bundles/EXM104_FHIR4-8.1.000/EXM104_FHIR4-8.1.000-bundle.json
-	touch .seed-cqf-ruler-r4
-
-.seed-cqf-ruler-no-vs-r4:
-	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-r4`; do printf '.'; sleep 5; done
-	curl -X PUT \
-  http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM104-FHIR4-8.1.000 \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir4/bundles/EXM104_FHIR4-8.1.000/EXM104_FHIR4-8.1.000-files/measure-EXM104_FHIR4-8.1.000.json
-	curl -X PUT \
-  http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM104-FHIR4-8.1.000 \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir4/bundles/EXM104_FHIR4-8.1.000/EXM104_FHIR4-8.1.000-files/library-EXM104_FHIR4-8.1.000.json
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-r4/fhir \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir4/bundles/EXM105_FHIR4-8.1.000/EXM105_FHIR4-8.1.000-files/library-deps-EXM105_FHIR4-8.1.000-bundle.json
-	touch .seed-cqf-ruler-no-vs-r4
-
-synthea:
-	git clone --single-branch --branch abacus --depth 1 https://github.com/projecttacoma/synthea.git
+	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 10
-SYNTHEA_PROPS := synthea/src/main/resources/synthea.properties
-generate-patients:
+SYNTHEA_PROPS := ../synthea/src/main/resources/synthea.properties
+
+generate-patients-stu3:
 	sed 's/exporter.fhir.export = true/exporter.fhir.export = false/g' $(SYNTHEA_PROPS) > temp
 	sed 's/exporter.fhir_stu3.export = false/exporter.fhir_stu3.export = true/g' temp > $(SYNTHEA_PROPS)
 	rm -rf temp
-	cd synthea && ./run_synthea -a 18-21 -p $(PATIENT_COUNT) -m stroke_exm_104*
+	cd ../synthea && ./run_synthea -a 18-21 -p $(PATIENT_COUNT) -m stroke_exm_104*
 
 generate-patients-r4:
 	sed 's/exporter.fhir.export = false/exporter.fhir.export = true/g' $(SYNTHEA_PROPS) > temp
 	sed 's/exporter.fhir_stu3.export = true/exporter.fhir_stu3.export = false/g' temp > $(SYNTHEA_PROPS)
 	rm -rf temp
-	cd synthea && ./run_synthea -a 19-21 -p $(PATIENT_COUNT) -m stroke_exm_104_r4*
+	cd ../synthea && ./run_synthea -a 19-21 -p $(PATIENT_COUNT) -m stroke_exm_104_r4*
 
-calculate-patients:
-	calculate-bundles -d ./synthea/output/fhir_stu3 -c ./connectathon/fhir3/cql/EXM104_FHIR3-8.1.000.cql -u http://localhost:8080/cqf-ruler-dstu3/fhir -s "2018-01-01" -e "2018-12-31" -m measure-EXM104-FHIR3-8.1.000
+calculate-patients-stu3:
+	mkdir -p stu3
+	cd stu3 && calculate-bundles -d ../../synthea/output/fhir_stu3 -c ../../connectathon/fhir3/cql/EXM104_FHIR3-8.1.000.cql -u http://localhost:8080/cqf-ruler-dstu3/fhir -s "2018-01-01" -e "2018-12-31" -m measure-EXM104-FHIR3-8.1.000
 
 calculate-patients-r4:
-	calculate-bundles -d ./synthea/output/fhir -c ./connectathon/fhir4/cql/EXM104_FHIR4-8.1.000.cql -u http://localhost:8080/cqf-ruler-r4/fhir -s "2019-01-01" -e "2019-12-31" -m measure-EXM104-FHIR4-8.1.000
-
-clean:
-	-docker stop cqf-ruler
-	-rm -rf synthea output connectathon .cqf-ruler .seed-cqf-ruler .seed-cqf-ruler-r4 .seed-cqf-ruler-no-vs .seed-cqf-ruler-no-vs-r4 .generate-patients .generate-patients-r4 .calculate-patients .setup-cqf-ruler .setup-cqf-ruler-r4 temp
-
-.PHONY: all clean info
+	mkdir -p r4
+	cd r4 && calculate-bundles -d ../../synthea/output/fhir -c ../../connectathon/fhir4/cql/EXM104_FHIR4-8.1.000.cql -u http://localhost:8080/cqf-ruler-r4/fhir -s "2019-01-01" -e "2019-12-31" -m measure-EXM104-FHIR4-8.1.000

--- a/EXM_105/Makefile
+++ b/EXM_105/Makefile
@@ -1,56 +1,13 @@
-all: info .setup-cqf-ruler synthea generate-patients calculate-patients
+all stu3: info generate-patients-stu3 calculate-patients-stu3
 
 info:
-	$(info `make` will cache the cqf-ruler, connectathon, and synythea setups, but repeat patient generation and calculation.)
-	$(info To repeat all steps, do `make clean; make`)
-
-.setup-cqf-ruler: .cqf-ruler connectathon .seed-cqf-ruler
-	touch .setup-cqf-ruler
-
-.cqf-ruler:
-	docker run --name cqf-ruler --rm -dit -p 8080:8080 contentgroup/cqf-ruler:develop
-	touch .cqf-ruler
-
-connectathon:
-	git clone https://github.com/DBCG/connectathon.git
-
-.seed-cqf-ruler:
-	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-dstu3/fhir \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/bundles/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-bundle.json
-	touch .seed-cqf-ruler
-
-.seed-cqf-ruler-no-vs:
-	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-dstu3/fhir \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/bundles/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/library-deps-EXM105_FHIR3-8.0.000-bundle.json
-	curl -X PUT \
-  http://localhost:8080/cqf-ruler-dstu3/fhir/Library/library-EXM105-FHIR3-8.0.000 \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/bundles/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/library-EXM105_FHIR3-8.0.000.json
-	curl -X PUT \
-  http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM105-FHIR3-8.0.000 \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/bundles/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/measure-EXM105_FHIR3-8.0.000.json
-	touch .seed-cqf-ruler-no-vs
-
-synthea:
-	git clone --single-branch --branch abacus --depth 1 https://github.com/projecttacoma/synthea.git
+	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 30
-generate-patients:
-	cd synthea && ./run_synthea -a 18-21 -p $(PATIENT_COUNT) -m stroke_exm_105
+generate-patients-stu3:
+	cd ../synthea && ./run_synthea -a 18-21 -p $(PATIENT_COUNT) -m stroke_exm_105
 
-CQL_FILE := connectathon/fhir3/bundles/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/EXM105_FHIR3-8.0.000.cql
-calculate-patients:
-	calculate-bundles -d ./synthea/output/fhir_stu3 -c $(CQL_FILE) -u http://localhost:8080/cqf-ruler-dstu3/fhir --measure-id measure-EXM105-FHIR3-8.0.000
-
-clean:
-	-docker stop cqf-ruler
-	-rm -rf synthea output connectathon .cqf-ruler .seed-cqf-ruler .seed-cqf-ruler-no-vs .generate-patients .calculate-patients .setup-cqf-ruler
-
-.PHONY: all clean info
+CQL_FILE := ../../connectathon/fhir3/bundles/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/EXM105_FHIR3-8.0.000.cql
+calculate-patients-stu3:
+	mkdir -p stu3
+	cd stu3 && calculate-bundles -d ../../synthea/output/fhir_stu3 -c $(CQL_FILE) -u http://localhost:8080/cqf-ruler-dstu3/fhir --measure-id measure-EXM105-FHIR3-8.0.000

--- a/EXM_124/Makefile
+++ b/EXM_124/Makefile
@@ -1,98 +1,29 @@
-all: info .setup-cqf-ruler synthea generate-patients calculate-patients
+all r4: info generate-patients-r4 calculate-patients-r4
 
-r4: info .setup-cqf-ruler-r4 synthea generate-patients-r4 calculate-patients-r4
+stu3: info generate-patients-stu3 calculate-patients-stu3
 
 info:
-	$(info `make` will cache the cqf-ruler, connectathon, and synythea setups, but repeat patient generation and calculation.)
-	$(info To repeat all steps, do `make clean; make`)
-
-.setup-cqf-ruler: .cqf-ruler connectathon .seed-cqf-ruler
-	touch .setup-cqf-ruler
-
-.setup-cqf-ruler-r4: .cqf-ruler connectathon .seed-cqf-ruler-r4
-	touch .setup-cqf-ruler-r4
-
-.cqf-ruler:
-	docker run --name cqf-ruler --rm -dit -p 8080:8080 contentgroup/cqf-ruler
-	touch .cqf-ruler
-
-connectathon:
-	git clone https://github.com/DBCG/connectathon.git
-
-.seed-cqf-ruler:
-	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-dstu3/fhir \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/bundles/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-bundle.json
-	touch .seed-cqf-ruler
-
-.seed-cqf-ruler-r4:
-	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-r4`; do printf '.'; sleep 5; done
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-r4/fhir \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir4/bundles/EXM124_FHIR4-8.2.000/EXM124_FHIR4-8.2.000-bundle.json
-	touch .seed-cqf-ruler-r4
-
-.seed-cqf-ruler-no-vs:
-	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
-	curl -X PUT \
-  http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM124-FHIR3-7.2.000 \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/bundles/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-files/measure-EXM124_FHIR3-7.2.000.json
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-dstu3/fhir \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/bundles/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-files/library-deps-EXM124_FHIR3-7.2.000-bundle.json
-	curl -X PUT \
-  http://localhost:8080/cqf-ruler-dstu3/fhir/Library/library-EXM124-FHIR3-7.2.000 \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/bundles/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-files/library-EXM124_FHIR3-7.2.000.json
-	touch .seed-cqf-ruler-no-vs
-
-.seed-cqf-ruler-no-vs-r4:
-	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-r4`; do printf '.'; sleep 5; done
-	curl -X PUT \
-  http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM124-FHIR4-8.2.000 \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir4/bundles/EXM124_FHIR4-8.2.000/EXM124_FHIR4-8.2.000-files/measure-EXM124_FHIR4-8.2.000.json
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-r4/fhir \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir4/bundles/EXM124_FHIR4-8.2.000/EXM124_FHIR4-8.2.000-files/library-deps-EXM124_FHIR4-8.2.000-bundle.json
-	curl -X PUT \
-  http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM124-FHIR4-8.2.000 \
-  -H 'Content-Type: application/json' \
-	-d @./connectathon/fhir4/bundles/EXM124_FHIR4-8.2.000/EXM124_FHIR4-8.2.000-files/library-EXM124_FHIR4-8.2.000.json
-	touch .seed-cqf-ruler-no-vs-r4
-
-synthea:
-	git clone --single-branch --branch abacus https://github.com/projecttacoma/synthea.git
+	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 10
-SYNTHEA_PROPS := synthea/src/main/resources/synthea.properties
+SYNTHEA_PROPS := ../synthea/src/main/resources/synthea.properties
 
-generate-patients:
+generate-patients-stu3:
 	sed 's/exporter.fhir.export = true/exporter.fhir.export = false/g' $(SYNTHEA_PROPS) > temp
 	sed 's/exporter.fhir_stu3.export = false/exporter.fhir_stu3.export = true/g' temp > $(SYNTHEA_PROPS)
 	rm -rf temp
-	cd synthea && ./run_synthea -a 52-52 -g F -p $(PATIENT_COUNT) -m breast_cancer_exm124*
+	cd ../synthea && ./run_synthea -a 52-52 -g F -p $(PATIENT_COUNT) -m breast_cancer_exm124*
 
 generate-patients-r4:
 	sed 's/exporter.fhir.export = false/exporter.fhir.export = true/g' $(SYNTHEA_PROPS) > temp
 	sed 's/exporter.fhir_stu3.export = true/exporter.fhir_stu3.export = false/g' temp > $(SYNTHEA_PROPS)
 	rm -rf temp
-	cd synthea && ./run_synthea -a 52-52 -g F -p $(PATIENT_COUNT) -m breast_cancer_exm124-r4*
+	cd ../synthea && ./run_synthea -a 52-52 -g F -p $(PATIENT_COUNT) -m breast_cancer_exm124-r4*
 
-calculate-patients:
-	calculate-bundles -d ./synthea/output/fhir_stu3 -c ./connectathon/fhir3/bundles/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-files/EXM124_FHIR3-7.2.000.cql -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM124-FHIR3-7.2.000
+calculate-patients-stu3:
+	mkdir -p stu3
+	cd stu3 && calculate-bundles -d ../../synthea/output/fhir_stu3 -c ../../connectathon/fhir3/bundles/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-files/EXM124_FHIR3-7.2.000.cql -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM124-FHIR3-7.2.000
 
 calculate-patients-r4:
-	calculate-bundles -d ./synthea/output/fhir -c ./connectathon/fhir4/bundles/EXM124_FHIR4-8.2.000/EXM124_FHIR4-8.2.000-files/EXM124_FHIR4-8.2.000.cql -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM124-FHIR4-8.2.000
-
-clean:
-	-docker stop cqf-ruler
-	-rm -rf synthea output connectathon .cqf-ruler .seed-cqf-ruler .seed-cqf-ruler-r4 .seed-cqf-ruler-no-vs .seed-cqf-ruler-no-vs-r4 .generate-patients .generate-patients-r4 .setup-cqf-ruler .setup-cqf-ruler-r4 temp
-
-.PHONY: all clean info
+	mkdir -p r4
+	cd r4 && calculate-bundles -d ../../synthea/output/fhir -c ../../connectathon/fhir4/bundles/EXM124_FHIR4-8.2.000/EXM124_FHIR4-8.2.000-files/EXM124_FHIR4-8.2.000.cql -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM124-FHIR4-8.2.000

--- a/EXM_125/Makefile
+++ b/EXM_125/Makefile
@@ -1,97 +1,29 @@
-all: info .setup-cqf-ruler synthea generate-patients calculate-patients
+all r4: info generate-patients-r4 calculate-patients-r4
 
-r4: info .setup-cqf-ruler-r4 synthea generate-patients-r4 calculate-patients-r4
+stu3: info generate-patients-stu3 calculate-patients-stu3
 
 info:
-	$(info `make` will cache the cqf-ruler, connectathon, and synythea setups, but repeat patient generation and calculation.)
-	$(info To repeat all steps, do `make clean; make`)
-
-.setup-cqf-ruler: .cqf-ruler connectathon .seed-cqf-ruler
-	touch .setup-cqf-ruler
-
-.setup-cqf-ruler-r4: .cqf-ruler connectathon .seed-cqf-ruler-r4
-	touch .setup-cqf-ruler-r4
-
-.cqf-ruler:
-	docker run --name cqf-ruler --rm -dit -p 8080:8080 contentgroup/cqf-ruler
-	touch .cqf-ruler
-
-connectathon:
-	git clone https://github.com/DBCG/connectathon.git
-
-.seed-cqf-ruler:
-	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-dstu3/fhir \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/bundles/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-bundle.json
-	touch .seed-cqf-ruler
-
-.seed-cqf-ruler-r4:
-	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-r4`; do printf '.'; sleep 5; done
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-r4/fhir \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir4/bundles/EXM125_FHIR4-7.2.000/EXM125_FHIR4-7.2.000-bundle.json
-	touch .seed-cqf-ruler-r4
-
-.seed-cqf-ruler-no-vs:
-	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
-	curl -X PUT \
-  http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM125-FHIR3-7.2.000 \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/bundles/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-files/measure-EXM125_FHIR3-7.2.000.json
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-dstu3/fhir \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/bundles/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-files/library-deps-EXM125_FHIR3-7.2.000-bundle.json
-	curl -X PUT \
-  http://localhost:8080/cqf-ruler-dstu3/fhir/Library/library-EXM125-FHIR3-7.2.000 \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/bundles/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-files/library-EXM125_FHIR3-7.2.000.json
-	touch .seed-cqf-ruler-no-vs
-
-.seed-cqf-ruler-no-vs-r4:
-	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-r4`; do printf '.'; sleep 5; done
-	curl -X PUT \
-  http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM125_FHIR4-7.2.000 \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir4/bundles/EXM125_FHIR4-7.2.000/EXM125_FHIR4-7.2.000-files/measure-EXM125_FHIR4-7.2.000.json
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-r4/fhir \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir4/bundles/EXM125_FHIR4-7.2.000/EXM125_FHIR4-7.2.000-files/library-deps-EXM125_FHIR4-7.2.000-bundle.json
-	curl -X PUT \
-  http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM125-FHIR4-7.2.000 \
-  -H 'Content-Type: application/json' \
-	-d @./connectathon/fhir4/bundles/EXM125_FHIR4-7.2.000/EXM125_FHIR4-7.2.000-files/library-EXM125_FHIR4-7.2.000.json
-	touch .seed-cqf-ruler-no-vs-r4
-
-synthea:
-	git clone --single-branch --branch abacus https://github.com/projecttacoma/synthea.git
+	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 10
-SYNTHEA_PROPS := synthea/src/main/resources/synthea.properties
-generate-patients:
+SYNTHEA_PROPS := ../synthea/src/main/resources/synthea.properties
+
+generate-patients-stu3:
 	sed 's/exporter.fhir.export = true/exporter.fhir.export = false/g' $(SYNTHEA_PROPS) > temp
 	sed 's/exporter.fhir_stu3.export = false/exporter.fhir_stu3.export = true/g' temp > $(SYNTHEA_PROPS)
 	rm -rf temp
-	cd synthea && ./run_synthea -a 52-52 -g F -p $(PATIENT_COUNT) -m EXM125*
+	cd ../synthea && ./run_synthea -a 52-52 -g F -p $(PATIENT_COUNT) -m EXM125*
 
 generate-patients-r4:
 	sed 's/exporter.fhir.export = false/exporter.fhir.export = true/g' $(SYNTHEA_PROPS) > temp
 	sed 's/exporter.fhir_stu3.export = true/exporter.fhir_stu3.export = false/g' temp > $(SYNTHEA_PROPS)
 	rm -rf temp
-	cd synthea && ./run_synthea -a 52-52 -g F -p $(PATIENT_COUNT) -m EXM125-r4*
+	cd ../synthea && ./run_synthea -a 52-52 -g F -p $(PATIENT_COUNT) -m EXM125-r4*
 
-calculate-patients:
-	calculate-bundles -d ./synthea/output/fhir_stu3 -c ./connectathon/fhir3/bundles/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-files/EXM125_FHIR3-7.2.000.cql -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM125-FHIR3-7.2.000
+calculate-patients-stu3:
+	mkdir -p stu3
+	cd stu3 && calculate-bundles -d ../../synthea/output/fhir_stu3 -c ../../connectathon/fhir3/bundles/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-files/EXM125_FHIR3-7.2.000.cql -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM125-FHIR3-7.2.000
 
 calculate-patients-r4:
-	calculate-bundles -d ./synthea/output/fhir -c ./connectathon/fhir4/bundles/EXM125_FHIR4-7.2.000/EXM125_FHIR4-7.2.000-files/EXM125_FHIR4-7.2.000.cql -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM125-FHIR4-7.2.000
-
-clean:
-	-docker stop cqf-ruler
-	-rm -rf synthea output connectathon .cqf-ruler .seed-cqf-ruler .seed-cqf-ruler-r4 .seed-cqf-ruler-no-vs .seed-cqf-ruler-no-vs-r4 .generate-patients .generate-patients-r4 .setup-cqf-ruler .setup-cqf-ruler-r4 temp
-
-.PHONY: all clean info
+	mkdir -p r4
+	cd r4 && calculate-bundles -d ../../synthea/output/fhir -c ../../connectathon/fhir4/bundles/EXM125_FHIR4-7.2.000/EXM125_FHIR4-7.2.000-files/EXM125_FHIR4-7.2.000.cql -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM125-FHIR4-7.2.000

--- a/EXM_130/Makefile
+++ b/EXM_130/Makefile
@@ -1,97 +1,29 @@
-all: info .setup-cqf-ruler synthea generate-patients calculate-patients
+all r4: info generate-patients-r4 calculate-patients-r4
 
-r4: info .setup-cqf-ruler-r4 synthea generate-patients-r4 calculate-patients-r4
+stu3: info generate-patients-stu3 calculate-patients-stu3
 
 info:
-	$(info `make` will cache the cqf-ruler, connectathon, and synythea setups, but repeat patient generation and calculation.)
-	$(info To repeat all steps, do `make clean; make`)
-
-.setup-cqf-ruler: .cqf-ruler connectathon .seed-cqf-ruler
-	touch .setup-cqf-ruler
-
-.setup-cqf-ruler-r4: .cqf-ruler connectathon .seed-cqf-ruler-r4
-	touch .setup-cqf-ruler-r4:
-
-.cqf-ruler:
-	docker run --name cqf-ruler --rm -dit -p 8080:8080 contentgroup/cqf-ruler:latest
-	touch .cqf-ruler
-
-connectathon:
-	git clone https://github.com/DBCG/connectathon.git
-
-.seed-cqf-ruler:
-	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-dstu3/fhir/ \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/bundles/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-bundle.json
-	touch .seed-cqf-ruler
-
-.seed-cqf-ruler-r4:
-	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-r4`; do printf '.'; sleep 5; done
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-r4/fhir/ \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir4/bundles/EXM130_FHIR4-7.2.000/EXM130_FHIR4-7.2.000-bundle.json
-	touch .seed-cqf-ruler-r4
-
-.seed-cqf-ruler-no-vs:
-	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
-	curl -X PUT \
-  http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM130-FHIR3-7.2.000 \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/bundles/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/measure-EXM130_FHIR3-7.2.000.json
-	curl -X PUT \
-  http://localhost:8080/cqf-ruler-dstu3/fhir/Library/library-EXM130-FHIR3-7.2.000 \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/bundles/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/library-EXM130_FHIR3-7.2.000.json
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-dstu3/fhir \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir3/bundles/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/library-deps-EXM130_FHIR3-7.2.000-bundle.json
-	touch .seed-cqf-ruler-no-vs
-
-.seed-cqf-ruler-no-vs-r4:
-	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-r4`; do printf '.'; sleep 5; done
-	curl -X PUT \
-  http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM130-FHIR4-7.2.000 \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir4/bundles/EXM130_FHIR4-7.2.000/EXM130_FHIR4-7.2.000-files/measure-EXM130_FHIR4-7.2.000.json
-	curl -X PUT \
-  http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM130-FHIR4-7.2.000 \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir4/bundles/EXM130_FHIR4-7.2.000/EXM130_FHIR4-7.2.000-files/library-EXM130_FHIR4-7.2.000.json 
-	curl -X POST \
-  http://localhost:8080/cqf-ruler-r4/fhir/ \
-  -H 'Content-Type: application/json' \
-	-d @connectathon/fhir4/bundles/EXM130_FHIR4-7.2.000/EXM130_FHIR4-7.2.000-files/library-deps-EXM130_FHIR4-7.2.000-bundle.json
-	touch .seed-cqf-ruler-no-vs-r4
-
-synthea:
-	git clone --single-branch --branch abacus https://github.com/projecttacoma/synthea.git
+	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 10
-SYNTHEA_PROPS := synthea/src/main/resources/synthea.properties
-generate-patients:
+SYNTHEA_PROPS := ../synthea/src/main/resources/synthea.properties
+
+generate-patients-stu3:
 	sed 's/exporter.fhir.export = true/exporter.fhir.export = false/g' $(SYNTHEA_PROPS) > temp
 	sed 's/exporter.fhir_stu3.export = false/exporter.fhir_stu3.export = true/g' temp > $(SYNTHEA_PROPS)
 	rm -rf temp
-	cd synthea && ./run_synthea -a 51-51 -p $(PATIENT_COUNT) -m EXM130*
+	cd ../synthea && ./run_synthea -a 51-51 -p $(PATIENT_COUNT) -m EXM130*
 
 generate-patients-r4:
 	sed 's/exporter.fhir.export = false/exporter.fhir.export = true/g' $(SYNTHEA_PROPS) > temp
 	sed 's/exporter.fhir_stu3.export = true/exporter.fhir_stu3.export = false/g' temp > $(SYNTHEA_PROPS)
 	rm -rf temp
-	cd synthea && ./run_synthea -a 51-51 -p $(PATIENT_COUNT) -m EXM130-r4*
+	cd ../synthea && ./run_synthea -a 51-51 -p $(PATIENT_COUNT) -m EXM130-r4*
 
-calculate-patients:
-	calculate-bundles -d ./synthea/output/fhir_stu3 -c ./connectathon/fhir3/bundles/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/EXM130_FHIR3-7.2.000.cql -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM130-FHIR3-7.2.000
+calculate-patients-stu3:
+	mkdir -p stu3
+	cd stu3 && calculate-bundles -d ../../synthea/output/fhir_stu3 -c ../../connectathon/fhir3/bundles/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/EXM130_FHIR3-7.2.000.cql -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM130-FHIR3-7.2.000
 
 calculate-patients-r4:
-	calculate-bundles -d ./synthea/output/fhir -c ./connectathon/fhir4/bundles/EXM130_FHIR4-7.2.000/EXM130_FHIR4-7.2.000-files/EXM130_FHIR4-7.2.000.cql -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM130-FHIR4-7.2.000
-
-clean:
-	-docker stop cqf-ruler
-	-rm -rf synthea output connectathon .cqf-ruler .seed-cqf-ruler .seed-cqf-ruler-r4 .seed-cqf-ruler-no-vs .seed-cqf-ruler-no-vs-r4 .generate-patients .generate-patients-r4 .calculate-patients .setup-cqf-ruler .setup-cqf-ruler-r4 temp
-
-.PHONY: all clean info
+	mkdir -p r4
+	cd r4 && calculate-bundles -d ../../synthea/output/fhir -c ../../connectathon/fhir4/bundles/EXM130_FHIR4-7.2.000/EXM130_FHIR4-7.2.000-files/EXM130_FHIR4-7.2.000.cql -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM130-FHIR4-7.2.000

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ stu3: .setup-cqf-ruler-stu3 synthea generate-patients-stu3 calculate-patients-st
 	touch .setup-cqf-ruler-r4
 
 .new-cqf-ruler:
+	docker pull contentgroup/cqf-ruler:develop
 	docker run --name cqf-ruler --rm -dit -p 8080:8080 contentgroup/cqf-ruler:develop
 	touch .new-cqf-ruler
 
@@ -23,7 +24,8 @@ connectathon:
 .wait-cqf-ruler:
 	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-r4`; do printf '.'; sleep 5; done
 
-.seed-measures-r4: .wait-cqf-ruler
+.seed-measures-r4:
+	make .wait-cqf-ruler
 	# CMS 104
 	curl -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM104-FHIR4-8.1.000 \
 		-H 'Content-Type: application/json' \
@@ -67,7 +69,8 @@ connectathon:
 	touch .seed-measures-r4
 
 
-.seed-vs-r4: .wait-cqf-ruler
+.seed-vs-r4:
+	make .wait-cqf-ruler
 	curl -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
 		-d @connectathon/fhir4/bundles/EXM104_FHIR4-8.1.000/EXM104_FHIR4-8.1.000-files/valuesets-EXM104_FHIR4-8.1.000-bundle.json
@@ -89,7 +92,8 @@ connectathon:
 	touch .seed-vs-r4
 
 
-.seed-measures-stu3: .wait-cqf-ruler
+.seed-measures-stu3:
+	make .wait-cqf-ruler
 	# EXM 104
 	curl -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
 		-H 'Content-Type: application/json' \
@@ -142,7 +146,8 @@ connectathon:
 		-d @connectathon/fhir3/bundles/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/measure-EXM130_FHIR3-7.2.000.json
 	touch .seed-measures-stu3
 	
-.seed-vs-stu3: .wait-cqf-ruler
+.seed-vs-stu3:
+	make .wait-cqf-ruler
 	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
 	curl -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
 		-H 'Content-Type: application/json' \
@@ -201,4 +206,4 @@ clean:
 	-rm .seed-vs-stu3
 	-rm .seed-vs-r4
 
-.PHONY: all clean info
+.PHONY: all clean info .wait-cqf-ruler

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ connectathon:
   		-H 'Content-Type: application/json' \
 		-d @./connectathon/fhir4/bundles/EXM124_FHIR4-8.2.000/EXM124_FHIR4-8.2.000-files/library-EXM124_FHIR4-8.2.000.json
 	# CMS 125
-	curl -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM125_FHIR4-7.2.000 \
+	curl -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM125-FHIR4-7.2.000 \
 		-H 'Content-Type: application/json' \
 		-d @connectathon/fhir4/bundles/EXM125_FHIR4-7.2.000/EXM125_FHIR4-7.2.000-files/measure-EXM125_FHIR4-7.2.000.json
 	curl -X POST http://localhost:8080/cqf-ruler-r4/fhir \

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,204 @@
-all: .restart-cqf-ruler .update-cqf-ruler-image
+all r4: .setup-cqf-ruler-r4 synthea generate-patients-r4 calculate-patients-r4
 
 info:
 	$(info usage: `make MEASURE_DIR=/path/to/measure/dir VERSION=x.y.z)
 
-.seed-cqf-ruler-no-vs:
-	make -C $(MEASURE_DIR) connectathon .seed-cqf-ruler-no-vs
-	touch .seed-cqf-ruler-no-vs
+stu3: .setup-cqf-ruler-stu3 synthea generate-patients-stu3 calculate-patients-stu3
 
-.run-load-script:
-	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
-	./load-cqf-ruler.sh $(MEASURE_DIR)
+.setup-cqf-ruler-stu3: .new-cqf-ruler connectathon .seed-measures-stu3 .seed-vs-stu3
+	touch .setup-cqf-ruler-stu3
 
-.restart-cqf-ruler:
-	-docker stop cqf-ruler
+.setup-cqf-ruler-r4: .new-cqf-ruler connectathon .seed-measures-r4 .seed-vs-r4
+	touch .setup-cqf-ruler-r4
+
+.new-cqf-ruler:
 	docker run --name cqf-ruler --rm -dit -p 8080:8080 contentgroup/cqf-ruler:develop
+	touch .new-cqf-ruler
 
-.update-cqf-ruler-image: .seed-cqf-ruler-no-vs .run-load-script
+connectathon:
+	$(info connectathon checks out a specific commit SHA in case filepaths are updated)
+	git clone https://github.com/DBCG/connectathon.git
+	cd connectathon && git checkout 52084217d33a9d9fc8d79664a535edb24557635b
+
+.wait-cqf-ruler:
+	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-r4`; do printf '.'; sleep 5; done
+
+.seed-measures-r4: .wait-cqf-ruler
+	# CMS 104
+	curl -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM104-FHIR4-8.1.000 \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir4/bundles/EXM104_FHIR4-8.1.000/EXM104_FHIR4-8.1.000-files/measure-EXM104_FHIR4-8.1.000.json
+	curl -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM104-FHIR4-8.1.000 \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir4/bundles/EXM104_FHIR4-8.1.000/EXM104_FHIR4-8.1.000-files/library-EXM104_FHIR4-8.1.000.json
+	curl -X POST http://localhost:8080/cqf-ruler-r4/fhir \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir4/bundles/EXM105_FHIR4-8.1.000/EXM105_FHIR4-8.1.000-files/library-deps-EXM105_FHIR4-8.1.000-bundle.json
+	# CMS 124
+	curl -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM124-FHIR4-8.2.000 \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir4/bundles/EXM124_FHIR4-8.2.000/EXM124_FHIR4-8.2.000-files/measure-EXM124_FHIR4-8.2.000.json
+	curl -X POST http://localhost:8080/cqf-ruler-r4/fhir \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir4/bundles/EXM124_FHIR4-8.2.000/EXM124_FHIR4-8.2.000-files/library-deps-EXM124_FHIR4-8.2.000-bundle.json
+	curl -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM124-FHIR4-8.2.000 \
+  		-H 'Content-Type: application/json' \
+		-d @./connectathon/fhir4/bundles/EXM124_FHIR4-8.2.000/EXM124_FHIR4-8.2.000-files/library-EXM124_FHIR4-8.2.000.json
+	# CMS 125
+	curl -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM125_FHIR4-7.2.000 \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir4/bundles/EXM125_FHIR4-7.2.000/EXM125_FHIR4-7.2.000-files/measure-EXM125_FHIR4-7.2.000.json
+	curl -X POST http://localhost:8080/cqf-ruler-r4/fhir \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir4/bundles/EXM125_FHIR4-7.2.000/EXM125_FHIR4-7.2.000-files/library-deps-EXM125_FHIR4-7.2.000-bundle.json
+	curl -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM125-FHIR4-7.2.000 \
+		-H 'Content-Type: application/json' \
+		-d @./connectathon/fhir4/bundles/EXM125_FHIR4-7.2.000/EXM125_FHIR4-7.2.000-files/library-EXM125_FHIR4-7.2.000.json
+	# CMS 130
+	curl -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM130-FHIR4-7.2.000 \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir4/bundles/EXM130_FHIR4-7.2.000/EXM130_FHIR4-7.2.000-files/measure-EXM130_FHIR4-7.2.000.json
+	curl -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM130-FHIR4-7.2.000 \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir4/bundles/EXM130_FHIR4-7.2.000/EXM130_FHIR4-7.2.000-files/library-EXM130_FHIR4-7.2.000.json 
+	curl -X POST http://localhost:8080/cqf-ruler-r4/fhir/ \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir4/bundles/EXM130_FHIR4-7.2.000/EXM130_FHIR4-7.2.000-files/library-deps-EXM130_FHIR4-7.2.000-bundle.json
+	touch .seed-measures-r4
+
+
+.seed-vs-r4: .wait-cqf-ruler
+	curl -X POST http://localhost:8080/cqf-ruler-r4/fhir \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir4/bundles/EXM104_FHIR4-8.1.000/EXM104_FHIR4-8.1.000-files/valuesets-EXM104_FHIR4-8.1.000-bundle.json
+	curl -X POST http://localhost:8080/cqf-ruler-r4/fhir \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir4/bundles/EXM124_FHIR4-8.2.000/EXM124_FHIR4-8.2.000-files/valuesets-EXM124_FHIR4-8.2.000-bundle.json
+	curl -X POST http://localhost:8080/cqf-ruler-r4/fhir \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir4/bundles/EXM125_FHIR4-7.2.000/EXM125_FHIR4-7.2.000-files/valuesets-EXM125_FHIR4-7.2.000-bundle.json
+	curl -X POST http://localhost:8080/cqf-ruler-r4/fhir \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir4/bundles/EXM130_FHIR4-7.2.000/EXM130_FHIR4-7.2.000-files/valuesets-EXM130_FHIR4-7.2.000-bundle.json
+	curl -X POST http://localhost:8080/cqf-ruler-r4/fhir \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir4/bundles/EXM124_FHIR4-8.2.000/EXM124_FHIR4-8.2.000-files/valuesets-EXM124_FHIR4-8.2.000-bundle.json
+	curl -X POST http://localhost:8080/cqf-ruler-r4/fhir \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir4/bundles/EXM124_FHIR4-8.2.000/EXM124_FHIR4-8.2.000-files/valuesets-EXM124_FHIR4-8.2.000-bundle.json
+	touch .seed-vs-r4
+
+
+.seed-measures-stu3: .wait-cqf-ruler
+	# EXM 104
+	curl -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir3/bundles/EXM104_FHIR3-8.1.000/EXM104_FHIR3-8.1.000-files/library-deps-EXM104_FHIR3-8.1.000-bundle.json
+	curl -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Library/library-EXM104-FHIR3-8.1.000 \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir3/bundles/EXM104_FHIR3-8.1.000/EXM104_FHIR3-8.1.000-files/library-EXM104_FHIR3-8.1.000.json
+	curl -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM104-FHIR3-8.1.000 \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir3/bundles/EXM104_FHIR3-8.1.000/EXM104_FHIR3-8.1.000-files/measure-EXM104_FHIR3-8.1.000.json
+	# EXM 105
+	curl -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir3/bundles/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/library-deps-EXM105_FHIR3-8.0.000-bundle.json
+	curl -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Library/library-EXM105-FHIR3-8.0.000 \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir3/bundles/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/library-EXM105_FHIR3-8.0.000.json
+	curl -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM105-FHIR3-8.0.000 \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir3/bundles/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/measure-EXM105_FHIR3-8.0.000.json
+	# EXM 124
+	curl -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir3/bundles/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-files/library-deps-EXM124_FHIR3-7.2.000-bundle.json
+	curl -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Library/library-EXM124-FHIR3-7.2.000 \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir3/bundles/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-files/library-EXM124_FHIR3-7.2.000.json
+	curl -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM124-FHIR3-7.2.000 \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir3/bundles/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-files/measure-EXM124_FHIR3-7.2.000.json
+	# EXM 125
+	curl -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir3/bundles/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-files/library-deps-EXM125_FHIR3-7.2.000-bundle.json
+	curl -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Library/library-EXM125-FHIR3-7.2.000 \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir3/bundles/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-files/library-EXM125_FHIR3-7.2.000.json
+	curl -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM125-FHIR3-7.2.000 \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir3/bundles/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-files/measure-EXM125_FHIR3-7.2.000.json
+	# EXM 130
+	curl -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir3/bundles/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/library-deps-EXM130_FHIR3-7.2.000-bundle.json
+	curl -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Library/library-EXM130-FHIR3-7.2.000 \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir3/bundles/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/library-EXM130_FHIR3-7.2.000.json
+	curl -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM130-FHIR3-7.2.000 \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir3/bundles/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/measure-EXM130_FHIR3-7.2.000.json
+	touch .seed-measures-stu3
+	
+.seed-vs-stu3: .wait-cqf-ruler
+	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
+	curl -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir3/bundles/EXM104_FHIR3-8.1.000/EXM104_FHIR3-8.1.000-files/valuesets-EXM104_FHIR3-8.1.000-bundle.json
+	curl -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir3/bundles/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/valuesets-EXM105_FHIR3-8.0.000-bundle.json
+	curl -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir3/bundles/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-files/valuesets-EXM124_FHIR3-7.2.000-bundle.json
+	curl -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir3/bundles/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-files/valuesets-EXM125_FHIR3-7.2.000-bundle.json
+	curl -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
+		-H 'Content-Type: application/json' \
+		-d @connectathon/fhir3/bundles/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/valuesets-EXM130_FHIR3-7.2.000-bundle.json
+	touch .seed-vs-stu3
+
+synthea:
+	git clone --single-branch --branch abacus https://github.com/projecttacoma/synthea.git
+
+PATIENT_COUNT := 10
+generate-patients-stu3:
+	make -C $(MEASURE_DIR) generate-patients-stu3
+
+calculate-patients-stu3:
+	make -C $(MEASURE_DIR) calculate-patients-stu3
+
+generate-patients-r4:
+	make -C $(MEASURE_DIR) generate-patients-r4
+
+calculate-patients-r4:
+	make -C $(MEASURE_DIR) calculate-patients-r4
+
+preload-stu3: clean .new-cqf-ruler connectathon .seed-measures-stu3 .run-load-script-stu3
+
+preload-r4: clean .new-cqf-ruler connectathon .seed-measures-r4 .run-load-script-r4
+
+.run-load-script-stu3: .wait-cqf-ruler
+	FHIR_VERSION=stu3 ./load-cqf-ruler.sh $(MEASURE_DIR)
+
+.run-load-script-r4: .wait-cqf-ruler
+	./load-cqf-ruler.sh $(MEASURE_DIR) FHIR_VERSION=r4
+
+.update-cqf-ruler-image:
 	./release-docker-image.sh $(VERSION)
 
 clean:
 	-docker stop cqf-ruler
-	-rm -rf .seed-cqf-ruler-no-vs
+	-rm -rf synthea/output
+	-rm .setup-cqf-ruler-stu3
+	-rm .setup-cqf-ruler-r4
+	-rm .new-cqf-ruler
+	-rm .seed-measures-stu3
+	-rm .seed-measures-r4
+	-rm .seed-vs-stu3
+	-rm .seed-vs-r4
 
 .PHONY: all clean info


### PR DESCRIPTION
### Summary
Each measure still needs a Makefile, but they're much smaller and simpler now. The "master" Makefile in the root of the repo is the only one you need to use from the command line to perform patient generation and preload images. The master makes calls to the measure Makefiles.

The master makefile at a high level has two distinct functions: generating patients, and preloading CQF Ruler docker images. Here are some example commands:

Generate patients for EXM 130:
```
make MEASURE_DIR=EXM_130 r4
```
```
make MEASURE_DIR=EXM_130 stu3
```

Preload a docker image:
```
make MEASURE_DIR=EXM_130 preload-r4
```
```
make MEASURE_DIR=EXM_130 preload-stu3
```

We now only have one `connectathon` clone and one `synthea` clone for the whole repo, rather than one for each measure. Also, all of the "seeding" is consolidated into one place, and is performed with an "all or nothing" approach. So even if you're only generating patients for measure A, it will seed the image with all of the measures. I made this decision because it helps consolidate all of our references to `connectathon` resources, and there is only a marginal performance hit (since we're now performing a bunch of technically unnecessary PUT and POST calls).

We still need to have small Makefiles for each measure, which the master Makefile calls. This essentially boils down to the fact that each measure has it's own Synthea module and it's own CQL file. There is probably still some room for further simplification/DRYing in this area, but this seemed like a reasonable major first step.

### Things to note
- No matter the measure, this now outputs to the single Synthea clone that exists in the root of the repo. As such, if you are calculating patients for multiple measures in a row, you will need to clear that directory between actions. `make clean` clears this directory, but the other steps performed by the `clean` aren't necessary between calculations.

### Testing
The only way to really test this is to run a bunch of commands against the master Makefile, testing generating patients and preloading images with different measures, using commands like the examples I gave above.