### PR TITLE
Update makefiles to new fbc command

### DIFF
--- a/EXM_104/Makefile
+++ b/EXM_104/Makefile
@@ -22,8 +22,8 @@ generate-patients-r4:
 
 calculate-patients-stu3:
 	mkdir -p stu3
-	cd stu3 && calculate-bundles -d ../../synthea/output/fhir_stu3 -c ../../connectathon/fhir3/cql/EXM104_FHIR3-8.1.000.cql -u http://localhost:8080/cqf-ruler-dstu3/fhir -s "2018-01-01" -e "2018-12-31" -m measure-EXM104-FHIR3-8.1.000
+	cd stu3 && calculate-bundles -d ../../synthea/output/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -s "2018-01-01" -e "2018-12-31" -m measure-EXM104-FHIR3-8.1.000
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../../synthea/output/fhir -c ../../connectathon/fhir4/cql/EXM104_FHIR4-8.1.000.cql -u http://localhost:8080/cqf-ruler-r4/fhir -s "2019-01-01" -e "2019-12-31" -m measure-EXM104-FHIR4-8.1.000
+	cd r4 && calculate-bundles -d ../../synthea/output/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -s "2019-01-01" -e "2019-12-31" -m measure-EXM104-FHIR4-8.1.000

--- a/EXM_105/Makefile
+++ b/EXM_105/Makefile
@@ -7,7 +7,6 @@ PATIENT_COUNT := 30
 generate-patients-stu3:
 	cd ../synthea && ./run_synthea -a 18-21 -p $(PATIENT_COUNT) -m stroke_exm_105
 
-CQL_FILE := ../../connectathon/fhir3/bundles/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/EXM105_FHIR3-8.0.000.cql
 calculate-patients-stu3:
 	mkdir -p stu3
-	cd stu3 && calculate-bundles -d ../../synthea/output/fhir_stu3 -c $(CQL_FILE) -u http://localhost:8080/cqf-ruler-dstu3/fhir --measure-id measure-EXM105-FHIR3-8.0.000
+	cd stu3 && calculate-bundles -d ../../synthea/output/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir --measure-id measure-EXM105-FHIR3-8.0.000

--- a/EXM_124/Makefile
+++ b/EXM_124/Makefile
@@ -22,8 +22,8 @@ generate-patients-r4:
 
 calculate-patients-stu3:
 	mkdir -p stu3
-	cd stu3 && calculate-bundles -d ../../synthea/output/fhir_stu3 -c ../../connectathon/fhir3/bundles/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-files/EXM124_FHIR3-7.2.000.cql -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM124-FHIR3-7.2.000
+	cd stu3 && calculate-bundles -d ../../synthea/output/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM124-FHIR3-7.2.000
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../../synthea/output/fhir -c ../../connectathon/fhir4/bundles/EXM124_FHIR4-8.2.000/EXM124_FHIR4-8.2.000-files/EXM124_FHIR4-8.2.000.cql -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM124-FHIR4-8.2.000
+	cd r4 && calculate-bundles -d ../../synthea/output/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM124-FHIR4-8.2.000

--- a/EXM_125/Makefile
+++ b/EXM_125/Makefile
@@ -22,8 +22,8 @@ generate-patients-r4:
 
 calculate-patients-stu3:
 	mkdir -p stu3
-	cd stu3 && calculate-bundles -d ../../synthea/output/fhir_stu3 -c ../../connectathon/fhir3/bundles/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-files/EXM125_FHIR3-7.2.000.cql -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM125-FHIR3-7.2.000
+	cd stu3 && calculate-bundles -d ../../synthea/output/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM125-FHIR3-7.2.000
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../../synthea/output/fhir -c ../../connectathon/fhir4/bundles/EXM125_FHIR4-7.2.000/EXM125_FHIR4-7.2.000-files/EXM125_FHIR4-7.2.000.cql -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM125-FHIR4-7.2.000
+	cd r4 && calculate-bundles -d ../../synthea/output/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM125-FHIR4-7.2.000

--- a/EXM_130/Makefile
+++ b/EXM_130/Makefile
@@ -22,8 +22,8 @@ generate-patients-r4:
 
 calculate-patients-stu3:
 	mkdir -p stu3
-	cd stu3 && calculate-bundles -d ../../synthea/output/fhir_stu3 -c ../../connectathon/fhir3/bundles/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/EXM130_FHIR3-7.2.000.cql -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM130-FHIR3-7.2.000
+	cd stu3 && calculate-bundles -d ../../synthea/output/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM130-FHIR3-7.2.000
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../../synthea/output/fhir -c ../../connectathon/fhir4/bundles/EXM130_FHIR4-7.2.000/EXM130_FHIR4-7.2.000-files/EXM130_FHIR4-7.2.000.cql -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM130-FHIR4-7.2.000
+	cd r4 && calculate-bundles -d ../../synthea/output/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM130-FHIR4-7.2.000


### PR DESCRIPTION
See https://github.com/projecttacoma/fhir-bundle-calculator/pull/14

## Testing

* Run `npm link path/to/fhir-bundle-calculator`
  * After doing this, can ensure that it's up to date by doing `calculate-bundles --version` (should output 3.0.3)
* Run `make MEASURE_DIR=your-fav-measure <r4 or stu3>`
