### PR TITLE
Change to synthea cli flag for FHIR version

### DIFF
--- a/EXM_104/Makefile
+++ b/EXM_104/Makefile
@@ -6,19 +6,12 @@ info:
 	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 10
-SYNTHEA_PROPS := ../synthea/src/main/resources/synthea.properties
 
 generate-patients-stu3:
-	sed 's/exporter.fhir.export = true/exporter.fhir.export = false/g' $(SYNTHEA_PROPS) > temp
-	sed 's/exporter.fhir_stu3.export = false/exporter.fhir_stu3.export = true/g' temp > $(SYNTHEA_PROPS)
-	rm -rf temp
-	cd ../synthea && ./run_synthea -a 18-21 -p $(PATIENT_COUNT) -m stroke_exm_104*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true -a 18-21 -p $(PATIENT_COUNT) -m stroke_exm_104*
 
 generate-patients-r4:
-	sed 's/exporter.fhir.export = false/exporter.fhir.export = true/g' $(SYNTHEA_PROPS) > temp
-	sed 's/exporter.fhir_stu3.export = true/exporter.fhir_stu3.export = false/g' temp > $(SYNTHEA_PROPS)
-	rm -rf temp
-	cd ../synthea && ./run_synthea -a 19-21 -p $(PATIENT_COUNT) -m stroke_exm_104_r4*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false -a 19-21 -p $(PATIENT_COUNT) -m stroke_exm_104_r4*
 
 calculate-patients-stu3:
 	mkdir -p stu3

--- a/EXM_105/Makefile
+++ b/EXM_105/Makefile
@@ -5,7 +5,7 @@ info:
 
 PATIENT_COUNT := 30
 generate-patients-stu3:
-	cd ../synthea && ./run_synthea -a 18-21 -p $(PATIENT_COUNT) -m stroke_exm_105
+	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true -a 18-21 -p $(PATIENT_COUNT) -m stroke_exm_105
 
 calculate-patients-stu3:
 	mkdir -p stu3

--- a/EXM_124/Makefile
+++ b/EXM_124/Makefile
@@ -6,19 +6,12 @@ info:
 	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 10
-SYNTHEA_PROPS := ../synthea/src/main/resources/synthea.properties
 
 generate-patients-stu3:
-	sed 's/exporter.fhir.export = true/exporter.fhir.export = false/g' $(SYNTHEA_PROPS) > temp
-	sed 's/exporter.fhir_stu3.export = false/exporter.fhir_stu3.export = true/g' temp > $(SYNTHEA_PROPS)
-	rm -rf temp
-	cd ../synthea && ./run_synthea -a 52-52 -g F -p $(PATIENT_COUNT) -m breast_cancer_exm124*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true -a 52-52 -g F -p $(PATIENT_COUNT) -m breast_cancer_exm124*
 
 generate-patients-r4:
-	sed 's/exporter.fhir.export = false/exporter.fhir.export = true/g' $(SYNTHEA_PROPS) > temp
-	sed 's/exporter.fhir_stu3.export = true/exporter.fhir_stu3.export = false/g' temp > $(SYNTHEA_PROPS)
-	rm -rf temp
-	cd ../synthea && ./run_synthea -a 52-52 -g F -p $(PATIENT_COUNT) -m breast_cancer_exm124-r4*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false -a 52-52 -g F -p $(PATIENT_COUNT) -m breast_cancer_exm124-r4*
 
 calculate-patients-stu3:
 	mkdir -p stu3

--- a/EXM_125/Makefile
+++ b/EXM_125/Makefile
@@ -6,19 +6,12 @@ info:
 	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 10
-SYNTHEA_PROPS := ../synthea/src/main/resources/synthea.properties
 
 generate-patients-stu3:
-	sed 's/exporter.fhir.export = true/exporter.fhir.export = false/g' $(SYNTHEA_PROPS) > temp
-	sed 's/exporter.fhir_stu3.export = false/exporter.fhir_stu3.export = true/g' temp > $(SYNTHEA_PROPS)
-	rm -rf temp
-	cd ../synthea && ./run_synthea -a 52-52 -g F -p $(PATIENT_COUNT) -m EXM125*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true -a 52-52 -g F -p $(PATIENT_COUNT) -m EXM125*
 
 generate-patients-r4:
-	sed 's/exporter.fhir.export = false/exporter.fhir.export = true/g' $(SYNTHEA_PROPS) > temp
-	sed 's/exporter.fhir_stu3.export = true/exporter.fhir_stu3.export = false/g' temp > $(SYNTHEA_PROPS)
-	rm -rf temp
-	cd ../synthea && ./run_synthea -a 52-52 -g F -p $(PATIENT_COUNT) -m EXM125-r4*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false -a 52-52 -g F -p $(PATIENT_COUNT) -m EXM125-r4*
 
 calculate-patients-stu3:
 	mkdir -p stu3

--- a/EXM_130/Makefile
+++ b/EXM_130/Makefile
@@ -6,19 +6,12 @@ info:
 	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 10
-SYNTHEA_PROPS := ../synthea/src/main/resources/synthea.properties
 
 generate-patients-stu3:
-	sed 's/exporter.fhir.export = true/exporter.fhir.export = false/g' $(SYNTHEA_PROPS) > temp
-	sed 's/exporter.fhir_stu3.export = false/exporter.fhir_stu3.export = true/g' temp > $(SYNTHEA_PROPS)
-	rm -rf temp
-	cd ../synthea && ./run_synthea -a 51-51 -p $(PATIENT_COUNT) -m EXM130*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true -a 51-51 -p $(PATIENT_COUNT) -m EXM130*
 
 generate-patients-r4:
-	sed 's/exporter.fhir.export = false/exporter.fhir.export = true/g' $(SYNTHEA_PROPS) > temp
-	sed 's/exporter.fhir_stu3.export = true/exporter.fhir_stu3.export = false/g' temp > $(SYNTHEA_PROPS)
-	rm -rf temp
-	cd ../synthea && ./run_synthea -a 51-51 -p $(PATIENT_COUNT) -m EXM130-r4*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false -a 51-51 -p $(PATIENT_COUNT) -m EXM130-r4*
 
 calculate-patients-stu3:
 	mkdir -p stu3


### PR DESCRIPTION
Example usage of this CLI flag can be seen at the bottom of [this page](https://github.com/synthetichealth/synthea/wiki/Developer-Setup-and-Running#running-syntheatm)

Removes the usage of `sed`, and set the desired FHIR version exports directly during the `./run_sythea` command.

`make MEASURE_DIR=x <r4 | stu3>` should generate the desired version based on which target you run.