### PR TITLE
Generate synthea patients in measure-specific directories by datetime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ r4
 .setup-cqf-ruler*
 *.csv
 .DS_Store
+synthea_output/

--- a/EXM_104/Makefile
+++ b/EXM_104/Makefile
@@ -8,15 +8,15 @@ info:
 PATIENT_COUNT := 10
 
 generate-patients-stu3:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true -a 18-21 -p $(PATIENT_COUNT) -m stroke_exm_104*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true --exporter.baseDirectory=../EXM_104/$(SYNTHEA_DIR)/ -a 18-21 -p $(PATIENT_COUNT) -m stroke_exm_104*
 
 generate-patients-r4:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false -a 19-21 -p $(PATIENT_COUNT) -m stroke_exm_104_r4*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_104/$(SYNTHEA_DIR)/ -a 19-21 -p $(PATIENT_COUNT) -m stroke_exm_104_r4*
 
 calculate-patients-stu3:
 	mkdir -p stu3
-	cd stu3 && calculate-bundles -d ../../synthea/output/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -s "2018-01-01" -e "2018-12-31" -m measure-EXM104-FHIR3-8.1.000
+	cd stu3 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -s "2018-01-01" -e "2018-12-31" -m measure-EXM104-FHIR3-8.1.000
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../../synthea/output/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -s "2019-01-01" -e "2019-12-31" -m measure-EXM104-FHIR4-8.1.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -s "2019-01-01" -e "2019-12-31" -m measure-EXM104-FHIR4-8.1.000

--- a/EXM_105/Makefile
+++ b/EXM_105/Makefile
@@ -6,17 +6,16 @@ info:
 	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 10
-
 generate-patients-stu3:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true -a 18-21 -p $(PATIENT_COUNT) -m stroke_exm_105*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true --exporter.baseDirectory=../EXM_105/$(SYNTHEA_DIR)/ -a 18-21 -p $(PATIENT_COUNT) -m stroke_exm_105*
 
 generate-patients-r4:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false -a 19-21 -p $(PATIENT_COUNT) -m stroke_exm_105_r4*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_105/$(SYNTHEA_DIR)/ -a 19-21 -p $(PATIENT_COUNT) -m stroke_exm_105_r4*
 
 calculate-patients-stu3:
 	mkdir -p stu3
-	cd stu3 && calculate-bundles -d ../../synthea/output/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir --measure-id measure-EXM105-FHIR3-8.0.000 -s "2018-01-01" -e "2018-12-31"
+	cd stu3 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir --measure-id measure-EXM105-FHIR3-8.0.000 -s "2018-01-01" -e "2018-12-31"
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../../synthea/output/fhir -u http://localhost:8080/cqf-ruler-r4/fhir --measure-id measure-EXM105-FHIR4-8.1.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir --measure-id measure-EXM105-FHIR4-8.1.000

--- a/EXM_124/Makefile
+++ b/EXM_124/Makefile
@@ -8,15 +8,15 @@ info:
 PATIENT_COUNT := 10
 
 generate-patients-stu3:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true -a 52-52 -g F -p $(PATIENT_COUNT) -m breast_cancer_exm124*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true --exporter.baseDirectory=../EXM_124/$(SYNTHEA_DIR)/ -a 52-52 -g F -p $(PATIENT_COUNT) -m breast_cancer_exm124*
 
 generate-patients-r4:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false -a 52-52 -g F -p $(PATIENT_COUNT) -m breast_cancer_exm124-r4*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_124/$(SYNTHEA_DIR)/ -a 52-52 -g F -p $(PATIENT_COUNT) -m breast_cancer_exm124-r4*
 
 calculate-patients-stu3:
 	mkdir -p stu3
-	cd stu3 && calculate-bundles -d ../../synthea/output/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM124-FHIR3-7.2.000
+	cd stu3 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM124-FHIR3-7.2.000
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../../synthea/output/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM124-FHIR4-8.2.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM124-FHIR4-8.2.000

--- a/EXM_125/Makefile
+++ b/EXM_125/Makefile
@@ -8,15 +8,15 @@ info:
 PATIENT_COUNT := 10
 
 generate-patients-stu3:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true -a 52-52 -g F -p $(PATIENT_COUNT) -m EXM125*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true --exporter.baseDirectory=../EXM_125/$(SYNTHEA_DIR)/ -a 52-52 -g F -p $(PATIENT_COUNT) -m EXM125*
 
 generate-patients-r4:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false -a 52-52 -g F -p $(PATIENT_COUNT) -m EXM125-r4*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_125/$(SYNTHEA_DIR)/ -a 52-52 -g F -p $(PATIENT_COUNT) -m EXM125-r4*
 
 calculate-patients-stu3:
 	mkdir -p stu3
-	cd stu3 && calculate-bundles -d ../../synthea/output/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM125-FHIR3-7.2.000
+	cd stu3 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM125-FHIR3-7.2.000
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../../synthea/output/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM125-FHIR4-7.2.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM125-FHIR4-7.2.000

--- a/EXM_130/Makefile
+++ b/EXM_130/Makefile
@@ -8,15 +8,15 @@ info:
 PATIENT_COUNT := 10
 
 generate-patients-stu3:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true -a 51-51 -p $(PATIENT_COUNT) -m EXM130*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true --exporter.baseDirectory=../EXM_130/$(SYNTHEA_DIR)/ -a 51-51 -p $(PATIENT_COUNT) -m EXM130*
 
 generate-patients-r4:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false -a 51-51 -p $(PATIENT_COUNT) -m EXM130-r4*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_130/$(SYNTHEA_DIR)/ -a 51-51 -p $(PATIENT_COUNT) -m EXM130-r4*
 
 calculate-patients-stu3:
 	mkdir -p stu3
-	cd stu3 && calculate-bundles -d ../../synthea/output/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM130-FHIR3-7.2.000
+	cd stu3 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM130-FHIR3-7.2.000
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../../synthea/output/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM130-FHIR4-7.2.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM130-FHIR4-7.2.000

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 all r4: .setup-cqf-ruler-r4 synthea generate-patients-r4 calculate-patients-r4
 
+export SYNTHEA_DIR := synthea_output/$(shell date +%Y-%m-%dT%H%M%S)
+
 info:
 	$(info usage: `make MEASURE_DIR=/path/to/measure/dir VERSION=x.y.z)
 
@@ -211,6 +213,7 @@ preload-r4: clean .new-cqf-ruler connectathon .seed-measures-r4 .run-load-script
 clean:
 	-docker stop cqf-ruler
 	-rm -rf synthea/output
+	-rm -rf EXM_*/synthea_output
 	-rm .setup-cqf-ruler-stu3
 	-rm .setup-cqf-ruler-r4
 	-rm .new-cqf-ruler


### PR DESCRIPTION
This allows you to run Synthea multiple times without getting overlapping patients, either between runs or between measures.

To test:
*  Run `make MEASURE_DIR=<measure directory>` for a couple of different measures. Note that the patients are now created in a `synthea_output/<datetime of job start>/fhir(-stu3)` directory inside the measure directory, rather than in `synthea/output/fhir(-stu3)`
* Check the eval-measure output for each measure to ensure that you're getting the patients you would expect in each measure (aka that you have IPOP/DENOM patients, proving that `synthea` and `calculate-bundles` are referencing the right directory)
* Run `make clean`, and see that all the individual `synthea_output` directories have been deleted. Note: the `rm -rf synthea/output` part of the `clean` target has been left for backwards-compatibility.