### PR TITLE
Add an 'all' target to the master Makefile to run all the r4 generations and calculations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,14 @@
-all r4: .setup-cqf-ruler-r4 synthea generate-patients-r4 calculate-patients-r4
-
+MEASURE_DIRS := $(shell ls -d EXM_*)
 export SYNTHEA_DIR := synthea_output/$(shell date +%Y-%m-%dT%H%M%S)
+
+r4: .setup-cqf-ruler-r4 synthea generate-patients-r4 calculate-patients-r4
+
+define gen_calc_pts
+	make -C $1 all;
+endef
+
+all: .setup-cqf-ruler-r4 synthea
+	$(foreach dir,$(MEASURE_DIRS),$(call gen_calc_pts,$(dir)))
 
 info:
 	$(info usage: `make MEASURE_DIR=/path/to/measure/dir VERSION=x.y.z)

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 MEASURE_DIRS := $(shell ls -d EXM_*)
 export SYNTHEA_DIR := synthea_output/$(shell date +%Y-%m-%dT%H%M%S)
 
-r4: .setup-cqf-ruler-r4 synthea generate-patients-r4 calculate-patients-r4
-
 define gen_calc_pts
 	make -C $1 all;
 endef
 
 all: .setup-cqf-ruler-r4 synthea
 	$(foreach dir,$(MEASURE_DIRS),$(call gen_calc_pts,$(dir)))
+
+r4: .setup-cqf-ruler-r4 synthea generate-patients-r4 calculate-patients-r4
 
 info:
 	$(info usage: `make MEASURE_DIR=/path/to/measure/dir VERSION=x.y.z)

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,15 @@ define gen_calc_pts
 	make -C $1 all;
 endef
 
+define load_all_pts
+	./load-cqf-ruler.sh $1 FHIR_VERSION=r4;
+endef
+
 all: .setup-cqf-ruler-r4 synthea
 	$(foreach dir,$(MEASURE_DIRS),$(call gen_calc_pts,$(dir)))
+
+load-all: .new-cqf-ruler .wait-cqf-ruler
+	$(foreach dir,$(MEASURE_DIRS),$(call load_all_pts,$(dir)))
 
 r4: .setup-cqf-ruler-r4 synthea generate-patients-r4 calculate-patients-r4
 


### PR DESCRIPTION
UPDATE: Merge away once approved! ~NOTE: DO NOT MERGE until this PR has been rebased on `master` after #16 has been merged.~

This PR adds a new `all` target to the top-level Makefile. This target﻿ will:
* setup cqf-ruler for r4 calculations
* download synthea (if needed)
* run the `make all` step for each subdirectory that follows the `EXM_*` pattern

The same also exists for STU3 (under `make all-stu3`)

This PR also adds `preload-all` and `preload-all-stu3` targets that do the same thing as the `preload` and `preload-stu3` targets, only with all measure directories.
