### PR TITLE
Check dependencies makefile

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+# Summary
+## New behavior
+## Code changes
+# Testing guidance

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,14 @@ define load_all_pts
 	./load-cqf-ruler.sh $1 FHIR_VERSION=$2;
 endef
 
-r4: .setup-cqf-ruler-r4 synthea generate-patients-r4 calculate-patients-r4
+r4: .check-dependencies .setup-cqf-ruler-r4 synthea generate-patients-r4 calculate-patients-r4
 
-stu3: .setup-cqf-ruler-stu3 synthea generate-patients-stu3 calculate-patients-stu3
+stu3: .check-dependencies .setup-cqf-ruler-stu3 synthea generate-patients-stu3 calculate-patients-stu3
 
-all all-r4: .setup-cqf-ruler-r4 synthea
+all all-r4: .check-dependencies .setup-cqf-ruler-r4 synthea
 	$(foreach dir,$(MEASURE_DIRS),$(call gen_calc_pts,$(dir),r4))
 
-all-stu3: .setup-cqf-ruler-stu3 synthea
+all-stu3: .check-dependencies .setup-cqf-ruler-stu3 synthea
 	$(foreach dir,$(MEASURE_DIRS),$(call gen_calc_pts,$(dir),stu3))
 
 preload-all preload-all-r4: clean .setup-cqf-ruler-r4 .wait-cqf-ruler
@@ -27,6 +27,9 @@ preload-all-stu3: clean .setup-cqf-ruler-stu3 .wait-cqf-ruler
 
 info:
 	$(info usage: `make MEASURE_DIR=/path/to/measure/dir VERSION=x.y.z)
+
+.check-dependencies:
+	npm install -g fhir-bundle-calculator
 
 .setup-cqf-ruler-stu3: .new-cqf-ruler connectathon .seed-measures-stu3 .seed-vs-stu3
 	touch .setup-cqf-ruler-stu3


### PR DESCRIPTION
# Summary
This PR adds auto updates/installs the to the latest version of the FHIR-Bundle-Calculator. 
Also added a simple PR template.

## New behavior
For the following commands a "check-dependency" step will be called before proceeding:
- make [measure] r4
- make [measure] stu3
- make all all-r4
- make all-stu3

This step will run the following command: `npm install -g fhir-bundle-calculator`

