### PR TITLE
FHIR401 support

### DIFF
--- a/EXM_104/Makefile
+++ b/EXM_104/Makefile
@@ -19,4 +19,4 @@ calculate-patients-stu3:
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -s "2019-01-01" -e "2019-12-31" -m measure-EXM104-FHIR4-8.1.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -s "2019-01-01" -e "2019-12-31" -m measure-EXM104-FHIR4-9.1.000

--- a/EXM_104/Makefile
+++ b/EXM_104/Makefile
@@ -19,4 +19,4 @@ calculate-patients-stu3:
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -s "2019-01-01" -e "2019-12-31" -m measure-EXM104-FHIR4-9.1.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -s "2019-01-01" -e "2019-12-31" -m measure-EXM104-9.1.000

--- a/EXM_105/Makefile
+++ b/EXM_105/Makefile
@@ -18,4 +18,4 @@ calculate-patients-stu3:
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir --measure-id measure-EXM105-FHIR4-9.1.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir --measure-id measure-EXM105-9.1.000

--- a/EXM_105/Makefile
+++ b/EXM_105/Makefile
@@ -18,4 +18,4 @@ calculate-patients-stu3:
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir --measure-id measure-EXM105-FHIR4-8.1.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir --measure-id measure-EXM105-FHIR4-9.1.000

--- a/EXM_124/Makefile
+++ b/EXM_124/Makefile
@@ -19,4 +19,4 @@ calculate-patients-stu3:
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM124-FHIR4-8.2.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM124-FHIR4-9.0.000

--- a/EXM_124/Makefile
+++ b/EXM_124/Makefile
@@ -19,4 +19,4 @@ calculate-patients-stu3:
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM124-FHIR4-9.0.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM124-9.0.000

--- a/EXM_125/Makefile
+++ b/EXM_125/Makefile
@@ -19,4 +19,4 @@ calculate-patients-stu3:
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM125-FHIR4-7.2.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM125-FHIR4-8.0.000

--- a/EXM_125/Makefile
+++ b/EXM_125/Makefile
@@ -19,4 +19,4 @@ calculate-patients-stu3:
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM125-FHIR4-8.0.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM125-8.0.000

--- a/EXM_130/Makefile
+++ b/EXM_130/Makefile
@@ -19,4 +19,4 @@ calculate-patients-stu3:
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM130-FHIR4-7.2.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM130-FHIR4-8.0.000

--- a/EXM_130/Makefile
+++ b/EXM_130/Makefile
@@ -11,7 +11,7 @@ generate-patients-stu3:
 	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true --exporter.baseDirectory=../EXM_130/$(SYNTHEA_DIR)/ -a 51-51 -p $(PATIENT_COUNT) -m EXM130*
 
 generate-patients-r4:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_130/$(SYNTHEA_DIR)/ -a 51-51 -p $(PATIENT_COUNT) -m EXM130-r4*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_130/$(SYNTHEA_DIR)/ -a 51-61 --exporter.years_of_history=11 -p $(PATIENT_COUNT) -m EXM130-r4*
 
 calculate-patients-stu3:
 	mkdir -p stu3

--- a/EXM_130/Makefile
+++ b/EXM_130/Makefile
@@ -19,4 +19,4 @@ calculate-patients-stu3:
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM130-FHIR4-8.0.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM130-8.0.000

--- a/EXM_506/Makefile
+++ b/EXM_506/Makefile
@@ -12,4 +12,4 @@ generate-patients-r4:
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM506-FHIR4-3.0.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM506-3.0.000

--- a/EXM_506/Makefile
+++ b/EXM_506/Makefile
@@ -12,4 +12,4 @@ generate-patients-r4:
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM506-FHIR4-2.0.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM506-FHIR4-3.0.000

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ connectathon:
 ifeq ($(BASE_DIR),connectathon)
 	$(info connectathon checks out a specific commit SHA in case filepaths are updated)
 	git clone https://github.com/DBCG/connectathon.git
-	cd connectathon && git checkout 77e61250343f46fec3903a7b19bc9d33bf921bd3
+	cd connectathon && git checkout c9c3dd163613f20142aa008da3a16b10d7e6d2ed
 endif
 
 VALUESET_FILES = $(shell find $(BASE_DIR)/fhir401/bundles -type f -name "valuesets*bundle.json")

--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,10 @@ connectathon:
 ifeq ($(BASE_DIR),connectathon)
 	$(info connectathon checks out a specific commit SHA in case filepaths are updated)
 	git clone https://github.com/DBCG/connectathon.git
-	cd connectathon && git checkout 8fbaf58758a5d0719dd4b526f5018a5b33d8272e
+	cd connectathon && git checkout 77e61250343f46fec3903a7b19bc9d33bf921bd3
 endif
 
-VALUESET_FILES = $(shell find $(BASE_DIR)/fhir4/bundles -type f -name "valuesets*bundle.json")
+VALUESET_FILES = $(shell find $(BASE_DIR)/fhir401/bundles -type f -name "valuesets*bundle.json")
 .copy-valuesets: connectathon synthea
 	cp $(VALUESET_FILES) synthea/src/main/resources/terminology
 	touch .copy-valuesets
@@ -67,65 +67,65 @@ VALUESET_FILES = $(shell find $(BASE_DIR)/fhir4/bundles -type f -name "valuesets
 .seed-measures-r4:
 	make .wait-cqf-ruler
 	# CMS 104
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM104-FHIR4-8.1.000 \
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM104-FHIR4-9.1.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir4/bundles/EXM104_FHIR4-8.1.000/EXM104_FHIR4-8.1.000-files/measure-EXM104_FHIR4-8.1.000.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM104-FHIR4-8.1.000 \
+		-d @$(BASE_DIR)/fhir401/bundles/EXM104_FHIR4-9.1.000/EXM104_FHIR4-9.1.000-files/measure-EXM104_FHIR4-9.1.000.json
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM104-FHIR4-9.1.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir4/bundles/EXM104_FHIR4-8.1.000/EXM104_FHIR4-8.1.000-files/library-EXM104_FHIR4-8.1.000.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM104_FHIR4-9.1.000/EXM104_FHIR4-9.1.000-files/library-EXM104_FHIR4-9.1.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir4/bundles/EXM104_FHIR4-8.1.000/EXM104_FHIR4-8.1.000-files/library-deps-EXM104_FHIR4-8.1.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM104_FHIR4-9.1.000/EXM104_FHIR4-9.1.000-files/library-deps-EXM104_FHIR4-9.1.000-bundle.json
 	# CMS 105
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM105-FHIR4-8.1.000 \
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM105-FHIR4-9.1.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir4/bundles/EXM105_FHIR4-8.1.000/EXM105_FHIR4-8.1.000-files/measure-EXM105_FHIR4-8.1.000.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM105-FHIR4-8.1.000 \
+		-d @$(BASE_DIR)/fhir401/bundles/EXM105_FHIR4-9.1.000/EXM105_FHIR4-9.1.000-files/measure-EXM105_FHIR4-9.1.000.json
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM105-FHIR4-9.1.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir4/bundles/EXM105_FHIR4-8.1.000/EXM105_FHIR4-8.1.000-files/library-EXM105_FHIR4-8.1.000.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM105_FHIR4-9.1.000/EXM105_FHIR4-9.1.000-files/library-EXM105_FHIR4-9.1.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir4/bundles/EXM105_FHIR4-8.1.000/EXM105_FHIR4-8.1.000-files/library-deps-EXM105_FHIR4-8.1.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM105_FHIR4-9.1.000/EXM105_FHIR4-9.1.000-files/library-deps-EXM105_FHIR4-9.1.000-bundle.json
 	# CMS 124
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM124-FHIR4-8.2.000 \
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM124-FHIR4-9.0.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir4/bundles/EXM124_FHIR4-8.2.000/EXM124_FHIR4-8.2.000-files/measure-EXM124_FHIR4-8.2.000.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM124_FHIR4-9.0.000/EXM124_FHIR4-9.0.000-files/measure-EXM124_FHIR4-9.0.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir4/bundles/EXM124_FHIR4-8.2.000/EXM124_FHIR4-8.2.000-files/library-deps-EXM124_FHIR4-8.2.000-bundle.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM124-FHIR4-8.2.000 \
+		-d @$(BASE_DIR)/fhir401/bundles/EXM124_FHIR4-9.0.000/EXM124_FHIR4-9.0.000-files/library-deps-EXM124_FHIR4-9.0.000-bundle.json
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM124-FHIR4-9.0.000 \
   		-H 'Content-Type: application/json' \
-		-d @./$(BASE_DIR)/fhir4/bundles/EXM124_FHIR4-8.2.000/EXM124_FHIR4-8.2.000-files/library-EXM124_FHIR4-8.2.000.json
+		-d @./$(BASE_DIR)/fhir401/bundles/EXM124_FHIR4-9.0.000/EXM124_FHIR4-9.0.000-files/library-EXM124_FHIR4-9.0.000.json
 	# CMS 125
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM125-FHIR4-7.2.000 \
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM125-FHIR4-8.0.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir4/bundles/EXM125_FHIR4-7.2.000/EXM125_FHIR4-7.2.000-files/measure-EXM125_FHIR4-7.2.000.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM125_FHIR4-8.0.000/EXM125_FHIR4-8.0.000-files/measure-EXM125_FHIR4-8.0.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir4/bundles/EXM125_FHIR4-7.2.000/EXM125_FHIR4-7.2.000-files/library-deps-EXM125_FHIR4-7.2.000-bundle.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM125-FHIR4-7.2.000 \
+		-d @$(BASE_DIR)/fhir401/bundles/EXM125_FHIR4-8.0.000/EXM125_FHIR4-8.0.000-files/library-deps-EXM125_FHIR4-8.0.000-bundle.json
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM125-FHIR4-8.0.000 \
 		-H 'Content-Type: application/json' \
-		-d @./$(BASE_DIR)/fhir4/bundles/EXM125_FHIR4-7.2.000/EXM125_FHIR4-7.2.000-files/library-EXM125_FHIR4-7.2.000.json
+		-d @./$(BASE_DIR)/fhir401/bundles/EXM125_FHIR4-8.0.000/EXM125_FHIR4-8.0.000-files/library-EXM125_FHIR4-8.0.000.json
 	# CMS 130
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM130-FHIR4-7.2.000 \
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM130-FHIR4-8.0.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir4/bundles/EXM130_FHIR4-7.2.000/EXM130_FHIR4-7.2.000-files/measure-EXM130_FHIR4-7.2.000.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM130-FHIR4-7.2.000 \
+		-d @$(BASE_DIR)/fhir401/bundles/EXM130_FHIR4-8.0.000/EXM130_FHIR4-8.0.000-files/measure-EXM130_FHIR4-8.0.000.json
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM130-FHIR4-8.0.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir4/bundles/EXM130_FHIR4-7.2.000/EXM130_FHIR4-7.2.000-files/library-EXM130_FHIR4-7.2.000.json 
+		-d @$(BASE_DIR)/fhir401/bundles/EXM130_FHIR4-8.0.000/EXM130_FHIR4-8.0.000-files/library-EXM130_FHIR4-8.0.000.json 
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir/ \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir4/bundles/EXM130_FHIR4-7.2.000/EXM130_FHIR4-7.2.000-files/library-deps-EXM130_FHIR4-7.2.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM130_FHIR4-8.0.000/EXM130_FHIR4-8.0.000-files/library-deps-EXM130_FHIR4-8.0.000-bundle.json
 	# CMS 506
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM506-FHIR4-2.0.000 \
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM506-FHIR4-3.0.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir4/bundles/EXM506_FHIR4-2.0.000/EXM506_FHIR4-2.0.000-files/measure-EXM506_FHIR4-2.0.000.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM506-FHIR4-2.0.000 \
+		-d @$(BASE_DIR)/fhir401/bundles/EXM506_FHIR4-2.0.000/EXM506_FHIR4-2.0.000-files/measure-EXM506_FHIR4-2.0.000.json
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM506-FHIR4-3.0.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir4/bundles/EXM506_FHIR4-2.0.000/EXM506_FHIR4-2.0.000-files/library-EXM506_FHIR4-2.0.000.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM506_FHIR4-2.0.000/EXM506_FHIR4-2.0.000-files/library-EXM506_FHIR4-2.0.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir/ \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir4/bundles/EXM506_FHIR4-2.0.000/EXM506_FHIR4-2.0.000-files/library-deps-EXM506_FHIR4-2.0.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM506_FHIR4-2.0.000/EXM506_FHIR4-2.0.000-files/library-deps-EXM506_FHIR4-2.0.000-bundle.json
 	touch .seed-measures-r4
 
 
@@ -133,22 +133,22 @@ VALUESET_FILES = $(shell find $(BASE_DIR)/fhir4/bundles -type f -name "valuesets
 	make .wait-cqf-ruler
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir4/bundles/EXM104_FHIR4-8.1.000/EXM104_FHIR4-8.1.000-files/valuesets-EXM104_FHIR4-8.1.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM104_FHIR4-9.1.000/EXM104_FHIR4-9.1.000-files/valuesets-EXM104_FHIR4-9.1.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir4/bundles/EXM105_FHIR4-8.1.000/EXM105_FHIR4-8.1.000-files/valuesets-EXM105_FHIR4-8.1.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM105_FHIR4-9.1.000/EXM105_FHIR4-9.1.000-files/valuesets-EXM105_FHIR4-9.1.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir4/bundles/EXM124_FHIR4-8.2.000/EXM124_FHIR4-8.2.000-files/valuesets-EXM124_FHIR4-8.2.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM124_FHIR4-9.0.000/EXM124_FHIR4-9.0.000-files/valuesets-EXM124_FHIR4-9.0.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir4/bundles/EXM125_FHIR4-7.2.000/EXM125_FHIR4-7.2.000-files/valuesets-EXM125_FHIR4-7.2.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM125_FHIR4-8.0.000/EXM125_FHIR4-8.0.000-files/valuesets-EXM125_FHIR4-8.0.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir4/bundles/EXM130_FHIR4-7.2.000/EXM130_FHIR4-7.2.000-files/valuesets-EXM130_FHIR4-7.2.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM130_FHIR4-8.0.000/EXM130_FHIR4-8.0.000-files/valuesets-EXM130_FHIR4-8.0.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir4/bundles/EXM506_FHIR4-2.0.000/EXM506_FHIR4-2.0.000-files/valuesets-EXM506_FHIR4-2.0.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM506_FHIR4-2.0.000/EXM506_FHIR4-2.0.000-files/valuesets-EXM506_FHIR4-2.0.000-bundle.json
 	touch .seed-vs-r4
 
 

--- a/Makefile
+++ b/Makefile
@@ -67,65 +67,65 @@ VALUESET_FILES = $(shell find $(BASE_DIR)/fhir401/bundles -type f -name "valuese
 .seed-measures-r4:
 	make .wait-cqf-ruler
 	# CMS 104
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM104-FHIR4-9.1.000 \
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM104-9.1.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM104_FHIR4-9.1.000/EXM104_FHIR4-9.1.000-files/measure-EXM104_FHIR4-9.1.000.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM104-FHIR4-9.1.000 \
+		-d @$(BASE_DIR)/fhir401/bundles/EXM104-9.1.000/EXM104-9.1.000-files/measure-EXM104-9.1.000.json
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM104-9.1.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM104_FHIR4-9.1.000/EXM104_FHIR4-9.1.000-files/library-EXM104_FHIR4-9.1.000.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM104-9.1.000/EXM104-9.1.000-files/library-EXM104-9.1.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM104_FHIR4-9.1.000/EXM104_FHIR4-9.1.000-files/library-deps-EXM104_FHIR4-9.1.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM104-9.1.000/EXM104-9.1.000-files/library-deps-EXM104-9.1.000-bundle.json
 	# CMS 105
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM105-FHIR4-9.1.000 \
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM105-9.1.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM105_FHIR4-9.1.000/EXM105_FHIR4-9.1.000-files/measure-EXM105_FHIR4-9.1.000.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM105-FHIR4-9.1.000 \
+		-d @$(BASE_DIR)/fhir401/bundles/EXM105-9.1.000/EXM105-9.1.000-files/measure-EXM105-9.1.000.json
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM105-9.1.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM105_FHIR4-9.1.000/EXM105_FHIR4-9.1.000-files/library-EXM105_FHIR4-9.1.000.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM105-9.1.000/EXM105-9.1.000-files/library-EXM105-9.1.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM105_FHIR4-9.1.000/EXM105_FHIR4-9.1.000-files/library-deps-EXM105_FHIR4-9.1.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM105-9.1.000/EXM105-9.1.000-files/library-deps-EXM105-9.1.000-bundle.json
 	# CMS 124
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM124-FHIR4-9.0.000 \
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM124-9.0.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM124_FHIR4-9.0.000/EXM124_FHIR4-9.0.000-files/measure-EXM124_FHIR4-9.0.000.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM124-9.0.000/EXM124-9.0.000-files/measure-EXM124-9.0.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM124_FHIR4-9.0.000/EXM124_FHIR4-9.0.000-files/library-deps-EXM124_FHIR4-9.0.000-bundle.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM124-FHIR4-9.0.000 \
+		-d @$(BASE_DIR)/fhir401/bundles/EXM124-9.0.000/EXM124-9.0.000-files/library-deps-EXM124-9.0.000-bundle.json
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM124-9.0.000 \
   		-H 'Content-Type: application/json' \
-		-d @./$(BASE_DIR)/fhir401/bundles/EXM124_FHIR4-9.0.000/EXM124_FHIR4-9.0.000-files/library-EXM124_FHIR4-9.0.000.json
+		-d @./$(BASE_DIR)/fhir401/bundles/EXM124-9.0.000/EXM124-9.0.000-files/library-EXM124-9.0.000.json
 	# CMS 125
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM125-FHIR4-8.0.000 \
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM125-8.0.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM125_FHIR4-8.0.000/EXM125_FHIR4-8.0.000-files/measure-EXM125_FHIR4-8.0.000.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM125-8.0.000/EXM125-8.0.000-files/measure-EXM125-8.0.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM125_FHIR4-8.0.000/EXM125_FHIR4-8.0.000-files/library-deps-EXM125_FHIR4-8.0.000-bundle.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM125-FHIR4-8.0.000 \
+		-d @$(BASE_DIR)/fhir401/bundles/EXM125-8.0.000/EXM125-8.0.000-files/library-deps-EXM125-8.0.000-bundle.json
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM125-8.0.000 \
 		-H 'Content-Type: application/json' \
-		-d @./$(BASE_DIR)/fhir401/bundles/EXM125_FHIR4-8.0.000/EXM125_FHIR4-8.0.000-files/library-EXM125_FHIR4-8.0.000.json
+		-d @./$(BASE_DIR)/fhir401/bundles/EXM125-8.0.000/EXM125-8.0.000-files/library-EXM125-8.0.000.json
 	# CMS 130
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM130-FHIR4-8.0.000 \
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM130-8.0.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM130_FHIR4-8.0.000/EXM130_FHIR4-8.0.000-files/measure-EXM130_FHIR4-8.0.000.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM130-FHIR4-8.0.000 \
+		-d @$(BASE_DIR)/fhir401/bundles/EXM130-8.0.000/EXM130-8.0.000-files/measure-EXM130-8.0.000.json
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM130-8.0.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM130_FHIR4-8.0.000/EXM130_FHIR4-8.0.000-files/library-EXM130_FHIR4-8.0.000.json 
+		-d @$(BASE_DIR)/fhir401/bundles/EXM130-8.0.000/EXM130-8.0.000-files/library-EXM130-8.0.000.json 
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir/ \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM130_FHIR4-8.0.000/EXM130_FHIR4-8.0.000-files/library-deps-EXM130_FHIR4-8.0.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM130-8.0.000/EXM130-8.0.000-files/library-deps-EXM130-8.0.000-bundle.json
 	# CMS 506
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM506-FHIR4-3.0.000 \
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM506-3.0.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM506_FHIR4-2.0.000/EXM506_FHIR4-2.0.000-files/measure-EXM506_FHIR4-2.0.000.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM506-FHIR4-3.0.000 \
+		-d @$(BASE_DIR)/fhir401/bundles/EXM506-3.0.000/EXM506-3.0.000-files/measure-EXM506-3.0.000.json
+	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM506-3.0.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM506_FHIR4-2.0.000/EXM506_FHIR4-2.0.000-files/library-EXM506_FHIR4-2.0.000.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM506-3.0.000/EXM506-3.0.000-files/library-EXM506-3.0.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir/ \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM506_FHIR4-2.0.000/EXM506_FHIR4-2.0.000-files/library-deps-EXM506_FHIR4-2.0.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM506-3.0.000/EXM506-3.0.000-files/library-deps-EXM506-3.0.000-bundle.json
 	touch .seed-measures-r4
 
 
@@ -133,22 +133,22 @@ VALUESET_FILES = $(shell find $(BASE_DIR)/fhir401/bundles -type f -name "valuese
 	make .wait-cqf-ruler
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM104_FHIR4-9.1.000/EXM104_FHIR4-9.1.000-files/valuesets-EXM104_FHIR4-9.1.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM104-9.1.000/EXM104-9.1.000-files/valuesets-EXM104-9.1.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM105_FHIR4-9.1.000/EXM105_FHIR4-9.1.000-files/valuesets-EXM105_FHIR4-9.1.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM105-9.1.000/EXM105-9.1.000-files/valuesets-EXM105-9.1.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM124_FHIR4-9.0.000/EXM124_FHIR4-9.0.000-files/valuesets-EXM124_FHIR4-9.0.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM124-9.0.000/EXM124-9.0.000-files/valuesets-EXM124-9.0.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM125_FHIR4-8.0.000/EXM125_FHIR4-8.0.000-files/valuesets-EXM125_FHIR4-8.0.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM125-8.0.000/EXM125-8.0.000-files/valuesets-EXM125-8.0.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM130_FHIR4-8.0.000/EXM130_FHIR4-8.0.000-files/valuesets-EXM130_FHIR4-8.0.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM130-8.0.000/EXM130-8.0.000-files/valuesets-EXM130-8.0.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM506_FHIR4-2.0.000/EXM506_FHIR4-2.0.000-files/valuesets-EXM506_FHIR4-2.0.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/EXM506-3.0.000/EXM506-3.0.000-files/valuesets-EXM506-3.0.000-bundle.json
 	touch .seed-vs-r4
 
 


### PR DESCRIPTION
# Summary

Since fhir401 will be the focus of MDs going forward, we want our testing tool to support it

## New behavior

Uses all fhir401 fixtures from the connectathon repo

## Code changes

All that changed is just modifications of the measure IDs used across the makefile

# Testing guidance

`make all-r4` should have no errors
