### PR TITLE
Measurement period config

### DIFF
--- a/EXM_104/Makefile
+++ b/EXM_104/Makefile
@@ -6,6 +6,8 @@ info:
 	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 10
+MP_START := 2020-01-01
+MP_END := 2020-12-31
 
 generate-patients-stu3:
 	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true --exporter.baseDirectory=../EXM_104/$(SYNTHEA_DIR)/ -a 18-21 -p $(PATIENT_COUNT) -m stroke_exm_104*
@@ -15,8 +17,8 @@ generate-patients-r4:
 
 calculate-patients-stu3:
 	mkdir -p stu3
-	cd stu3 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -s "2018-01-01" -e "2018-12-31" -m measure-EXM104-FHIR3-8.1.000
+	cd stu3 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM104-FHIR3-8.1.000 -s $(MP_START) -e $(MP_END)
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -s "2019-01-01" -e "2019-12-31" -m measure-EXM104-9.1.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM104-9.1.000 -s $(MP_START) -e $(MP_END)

--- a/EXM_105/Makefile
+++ b/EXM_105/Makefile
@@ -6,16 +6,19 @@ info:
 	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 10
+MP_START := 2020-01-01
+MP_END := 2020-12-31
+
 generate-patients-stu3:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true --exporter.baseDirectory=../EXM_105/$(SYNTHEA_DIR)/ -a 18-21 -p $(PATIENT_COUNT) -m stroke_exm_105*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true --exporter.baseDirectory=../EXM_105/$(SYNTHEA_DIR)/ --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -a 18-21 -p $(PATIENT_COUNT) -m stroke_exm_105*
 
 generate-patients-r4:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_105/$(SYNTHEA_DIR)/ -a 19-21 -p $(PATIENT_COUNT) -m stroke_exm_105_r4*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_105/$(SYNTHEA_DIR)/ --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -a 19-21 -p $(PATIENT_COUNT) -m stroke_exm_105_r4*
 
 calculate-patients-stu3:
 	mkdir -p stu3
-	cd stu3 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir --measure-id measure-EXM105-FHIR3-8.0.000 -s "2018-01-01" -e "2018-12-31"
+	cd stu3 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir --measure-id measure-EXM105-FHIR3-8.0.000 -s $(MP_START) -e $(MP_END)
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir --measure-id measure-EXM105-9.1.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir --measure-id measure-EXM105-9.1.000 -s $(MP_START) -e $(MP_END)

--- a/EXM_124/Makefile
+++ b/EXM_124/Makefile
@@ -6,17 +6,19 @@ info:
 	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 10
+MP_START := 2020-01-01
+MP_END := 2020-12-31
 
 generate-patients-stu3:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true --exporter.baseDirectory=../EXM_124/$(SYNTHEA_DIR)/ -a 52-52 -g F -p $(PATIENT_COUNT) -m breast_cancer_exm124*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true --exporter.baseDirectory=../EXM_124/$(SYNTHEA_DIR)/ --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -a 52-52 -g F -p $(PATIENT_COUNT) -m breast_cancer_exm124*
 
 generate-patients-r4:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_124/$(SYNTHEA_DIR)/ -a 52-52 -g F -p $(PATIENT_COUNT) -m breast_cancer_exm124-r4*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_124/$(SYNTHEA_DIR)/ --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -a 52-52 -g F -p $(PATIENT_COUNT) -m breast_cancer_exm124-r4*
 
 calculate-patients-stu3:
 	mkdir -p stu3
-	cd stu3 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM124-FHIR3-7.2.000
+	cd stu3 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM124-FHIR3-7.2.000 -s $(MP_START) -e $(MP_END)
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM124-9.0.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM124-9.0.000 -s $(MP_START) -e $(MP_END)

--- a/EXM_125/Makefile
+++ b/EXM_125/Makefile
@@ -5,13 +5,15 @@ stu3: info generate-patients-stu3 calculate-patients-stu3
 info:
 	$(info `make` will perform patient generation and calculation.)
 
-PATIENT_COUNT := 10
+PATIENT_COUNT := 15
+MP_START := 2018-01-01
+MP_END := 2018-12-31
 
 generate-patients-stu3:
 	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true --exporter.baseDirectory=../EXM_125/$(SYNTHEA_DIR)/ -a 52-52 -g F -p $(PATIENT_COUNT) -m EXM125*
 
 generate-patients-r4:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_125/$(SYNTHEA_DIR)/ -a 52-52 -g F -p $(PATIENT_COUNT) -m EXM125-r4*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_125/$(SYNTHEA_DIR)/ --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -a 53-55 -g F -p $(PATIENT_COUNT) -m EXM125-r4*
 
 calculate-patients-stu3:
 	mkdir -p stu3
@@ -19,4 +21,4 @@ calculate-patients-stu3:
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM125-8.0.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM125-8.0.000 -s $(MP_START) -e $(MP_END)

--- a/EXM_125/Makefile
+++ b/EXM_125/Makefile
@@ -6,18 +6,18 @@ info:
 	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 15
-MP_START := 2018-01-01
-MP_END := 2018-12-31
+MP_START := 2020-01-01
+MP_END := 2020-12-31
 
 generate-patients-stu3:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true --exporter.baseDirectory=../EXM_125/$(SYNTHEA_DIR)/ -a 52-52 -g F -p $(PATIENT_COUNT) -m EXM125*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true --exporter.baseDirectory=../EXM_125/$(SYNTHEA_DIR)/ --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -a 52-52 -g F -p $(PATIENT_COUNT) -m EXM125*
 
 generate-patients-r4:
 	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_125/$(SYNTHEA_DIR)/ --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -a 53-55 -g F -p $(PATIENT_COUNT) -m EXM125-r4*
 
 calculate-patients-stu3:
 	mkdir -p stu3
-	cd stu3 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM125-FHIR3-7.2.000
+	cd stu3 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM125-FHIR3-7.2.000 -s $(MP_START) -e $(MP_END)
 
 calculate-patients-r4:
 	mkdir -p r4

--- a/EXM_130/Makefile
+++ b/EXM_130/Makefile
@@ -6,17 +6,19 @@ info:
 	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 10
+MP_START := 2020-01-01
+MP_END := 2020-12-31
 
 generate-patients-stu3:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true --exporter.baseDirectory=../EXM_130/$(SYNTHEA_DIR)/ -a 51-51 -p $(PATIENT_COUNT) -m EXM130*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true --exporter.baseDirectory=../EXM_130/$(SYNTHEA_DIR)/ --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -a 51-51 -p $(PATIENT_COUNT) -m EXM130*
 
 generate-patients-r4:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_130/$(SYNTHEA_DIR)/ -a 51-61 --exporter.years_of_history=11 -p $(PATIENT_COUNT) -m EXM130-r4*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_130/$(SYNTHEA_DIR)/ --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -a 51-61 --exporter.years_of_history=11 -p $(PATIENT_COUNT) -m EXM130-r4*
 
 calculate-patients-stu3:
 	mkdir -p stu3
-	cd stu3 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM130-FHIR3-7.2.000
+	cd stu3 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM130-FHIR3-7.2.000 -s $(MP_START) -e $(MP_END)
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM130-8.0.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM130-8.0.000 -s $(MP_START) -e $(MP_END)

--- a/EXM_506/Makefile
+++ b/EXM_506/Makefile
@@ -6,10 +6,12 @@ info:
 	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 10
+MP_START := 2020-01-01
+MP_END := 2020-12-31
 
 generate-patients-r4:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_506/$(SYNTHEA_DIR)/ -p $(PATIENT_COUNT) -m EXM506-r4
+	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_506/$(SYNTHEA_DIR)/ -p $(PATIENT_COUNT) --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -m EXM506-r4
 
 calculate-patients-r4:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM506-3.0.000
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM506-3.0.000 -s $(MP_START) -e $(MP_END)

--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ VALUESET_FILES = $(shell find $(BASE_DIR)/fhir401/bundles -type f -name "valuese
 	touch .seed-vs-stu3
 
 synthea:
-	git clone --single-branch --branch abacus-config-attributes https://github.com/projecttacoma/synthea.git
+	git clone --single-branch --branch measurement-period-config https://github.com/projecttacoma/synthea.git
 
 PATIENT_COUNT := 10
 generate-patients-stu3:

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ info:
 	$(info usage: `make MEASURE_DIR=/path/to/measure/dir VERSION=x.y.z)
 
 .check-dependencies:
-	npm install -g fhir-bundle-calculator
+	#npm install -g fhir-bundle-calculator
 
 .setup-cqf-ruler-stu3: .new-cqf-ruler connectathon .seed-measures-stu3 .seed-vs-stu3
 	touch .setup-cqf-ruler-stu3
@@ -227,7 +227,7 @@ VALUESET_FILES = $(shell find $(BASE_DIR)/fhir401/bundles -type f -name "valuese
 	touch .seed-vs-stu3
 
 synthea:
-	git clone --single-branch --branch abacus https://github.com/projecttacoma/synthea.git
+	git clone --single-branch --branch abacus-config-attributes https://github.com/projecttacoma/synthea.git
 
 PATIENT_COUNT := 10
 generate-patients-stu3:

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ info:
 	$(info usage: `make MEASURE_DIR=/path/to/measure/dir VERSION=x.y.z)
 
 .check-dependencies:
-	#npm install -g fhir-bundle-calculator
+	npm install -g fhir-bundle-calculator
 
 .setup-cqf-ruler-stu3: .new-cqf-ruler connectathon .seed-measures-stu3 .seed-vs-stu3
 	touch .setup-cqf-ruler-stu3

--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ VALUESET_FILES = $(shell find $(BASE_DIR)/fhir401/bundles -type f -name "valuese
 	touch .seed-vs-stu3
 
 synthea:
-	git clone --single-branch --branch measurement-period-config https://github.com/projecttacoma/synthea.git
+	git clone --single-branch --branch abacus https://github.com/projecttacoma/synthea.git
 
 PATIENT_COUNT := 10
 generate-patients-stu3:
@@ -257,7 +257,7 @@ preload-r4: clean .new-cqf-ruler connectathon .seed-measures-r4 .run-load-script
 
 clean:
 	-docker stop cqf-ruler
-	-rm -rf synthea/output
+	-rm -rf synthea
 	-rm -rf EXM_*/synthea_output
 	-rm .setup-cqf-ruler-stu3
 	-rm .setup-cqf-ruler-r4


### PR DESCRIPTION
# Summary

Adds measurement period year for each arg

## New behavior

None really. Can change the MP start/end if you wish in the makefiles

## Code changes

* Include MP year in each makefile
* Pass in synthea cli arg + FBC cli arg for MP year

# Testing guidance

* Change the branch in the synthea target of the root makefile to`measurement-period-config`
* `make clean; make all-r4` and inspect results. try the same with different years
