### PR TITLE
Use fqm-execution for calculation by default

### DIFF
--- a/EXM_104-8.2.000/Makefile
+++ b/EXM_104-8.2.000/Makefile
@@ -1,24 +1,23 @@
-all r4: info generate-patients-r4 calculate-patients-r4
-
-stu3: info generate-patients-stu3 calculate-patients-stu3
+all r4: info generate-patients calculate-patients
 
 info:
 	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 10
+CALC_TYPE := fqm
 MP_START := 2019-01-01
 MP_END := 2019-12-31
 
-generate-patients-stu3:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true --exporter.baseDirectory=../EXM_104-8.2.000/$(SYNTHEA_DIR)/ -a 18-21 -p $(PATIENT_COUNT) -m stroke_exm_104*
+ifeq ($(strip $(CALC_TYPE)),fqm)
+	MEASURE_DIR_OPTS := -b ../../connectathon/fhir401/bundles/measure/EXM104-8.2.000/EXM104-8.2.000-bundle.json
+endif
+ifeq ($(strip $(CALC_TYPE)),http)
+	MEASURE_DIR_OPTS := -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM104-8.2.000
+endif
 
-generate-patients-r4:
+generate-patients:
 	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_104-8.2.000/$(SYNTHEA_DIR)/ -a 19-21 -p $(PATIENT_COUNT) -m stroke_exm_104_r4*
 
-calculate-patients-stu3:
-	mkdir -p stu3
-	cd stu3 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM104-FHIR3-8.1.000 -s $(MP_START) -e $(MP_END)
-
-calculate-patients-r4:
+calculate-patients:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM104-8.2.000 -s $(MP_START) -e $(MP_END)
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir $(MEASURE_DIR_OPTS) -s $(MP_START) -e $(MP_END) -t $(CALC_TYPE)

--- a/EXM_105-8.2.000/Makefile
+++ b/EXM_105-8.2.000/Makefile
@@ -1,24 +1,23 @@
-all r4: info generate-patients-r4 calculate-patients-r4
-
-stu3: info generate-patients-stu3 calculate-patients-stu3
+all r4: info generate-patients calculate-patients
 
 info:
 	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 10
+CALC_TYPE := fqm
 MP_START := 2020-01-01
 MP_END := 2020-12-31
 
-generate-patients-stu3:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true --exporter.baseDirectory=../EXM_105-8.2.000/$(SYNTHEA_DIR)/ --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -a 18-21 -p $(PATIENT_COUNT) -m stroke_exm_105*
+ifeq ($(strip $(CALC_TYPE)),fqm)
+	MEASURE_DIR_OPTS := -b ../../connectathon/fhir401/bundles/measure/EXM105-8.2.000/EXM105-8.2.000-bundle.json
+endif
+ifeq ($(strip $(CALC_TYPE)),http)
+	MEASURE_DIR_OPTS := -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM105-8.2.000
+endif
 
-generate-patients-r4:
+generate-patients:
 	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_105-8.2.000/$(SYNTHEA_DIR)/ --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -a 19-21 -p $(PATIENT_COUNT) -m stroke_exm_105_r4*
 
-calculate-patients-stu3:
-	mkdir -p stu3
-	cd stu3 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir --measure-id measure-EXM105-FHIR3-8.0.000 -s $(MP_START) -e $(MP_END)
-
-calculate-patients-r4:
+calculate-patients:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir --measure-id measure-EXM105-8.2.000 -s $(MP_START) -e $(MP_END)
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir $(MEASURE_DIR_OPTS) -s $(MP_START) -e $(MP_END) -t $(CALC_TYPE)

--- a/EXM_111-9.1.000/Makefile
+++ b/EXM_111-9.1.000/Makefile
@@ -1,15 +1,23 @@
-all r4: info generate-patients-r4 calculate-patients-r4
+all r4: info generate-patients calculate-patients
 
 info:
 	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 10
+CALC_TYPE := fqm
 MP_START := 2019-01-01
 MP_END := 2019-12-31
 
-generate-patients-r4:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_111-9.1.000/$(SYNTHEA_DIR)/ -p $(PATIENT_COUNT) --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -m EXM111*
+ifeq ($(strip $(CALC_TYPE)),fqm)
+	MEASURE_DIR_OPTS := -b ../../connectathon/fhir401/bundles/measure/EXM111-9.1.000/EXM111-9.1.000-bundle.json
+endif
+ifeq ($(strip $(CALC_TYPE)),http)
+	MEASURE_DIR_OPTS := -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM111-9.1.000
+endif
 
-calculate-patients-r4:
+generate-patients:
+	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_111-9.1.000/$(SYNTHEA_DIR)/ -p $(PATIENT_COUNT) --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -m EXM111*
+	
+calculate-patients:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM111-9.1.000 -s $(MP_START) -e $(MP_END)
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir $(MEASURE_DIR_OPTS) -s $(MP_START) -e $(MP_END) -t $(CALC_TYPE)

--- a/EXM_124-9.0.000/Makefile
+++ b/EXM_124-9.0.000/Makefile
@@ -1,24 +1,23 @@
-all r4: info generate-patients-r4 calculate-patients-r4
-
-stu3: info generate-patients-stu3 calculate-patients-stu3
+all r4: info generate-patients calculate-patients
 
 info:
 	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 10
+CALC_TYPE := fqm
 MP_START := 2020-01-01
 MP_END := 2020-12-31
 
-generate-patients-stu3:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true --exporter.baseDirectory=../EXM_124-9.0.000/$(SYNTHEA_DIR)/ --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -a 52-52 -g F -p $(PATIENT_COUNT) -m breast_cancer_exm124*
+ifeq ($(strip $(CALC_TYPE)),fqm)
+	MEASURE_DIR_OPTS := -b ../../connectathon/fhir401/bundles/measure/EXM124-9.0.000/EXM124-9.0.000-bundle.json
+endif
+ifeq ($(strip $(CALC_TYPE)),http)
+	MEASURE_DIR_OPTS := -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM124-9.0.000
+endif
 
-generate-patients-r4:
+generate-patients:
 	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_124-9.0.000/$(SYNTHEA_DIR)/ --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -a 52-52 -g F -p $(PATIENT_COUNT) -m breast_cancer_exm124-r4*
 
-calculate-patients-stu3:
-	mkdir -p stu3
-	cd stu3 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM124-FHIR3-7.2.000 -s $(MP_START) -e $(MP_END)
-
-calculate-patients-r4:
+calculate-patients:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM124-9.0.000 -s $(MP_START) -e $(MP_END)
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir $(MEASURE_DIR_OPTS) -s $(MP_START) -e $(MP_END) -t $(CALC_TYPE)

--- a/EXM_125-7.3.000/Makefile
+++ b/EXM_125-7.3.000/Makefile
@@ -1,24 +1,23 @@
-all r4: info generate-patients-r4 calculate-patients-r4
-
-stu3: info generate-patients-stu3 calculate-patients-stu3
+all r4: info generate-patients calculate-patients
 
 info:
 	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 15
+CALC_TYPE := fqm
 MP_START := 2020-01-01
 MP_END := 2020-12-31
 
-generate-patients-stu3:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true --exporter.baseDirectory=../EXM_125-7.3.000/$(SYNTHEA_DIR)/ --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -a 52-52 -g F -p $(PATIENT_COUNT) -m EXM125*
+ifeq ($(strip $(CALC_TYPE)),fqm)
+	MEASURE_DIR_OPTS := -b ../../connectathon/fhir401/bundles/measure/EXM125-7.3.000/EXM125-7.3.000-bundle.json
+endif
+ifeq ($(strip $(CALC_TYPE)),http)
+	MEASURE_DIR_OPTS := -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM125-7.3.000
+endif
 
-generate-patients-r4:
+generate-patients:
 	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_125-7.3.000/$(SYNTHEA_DIR)/ --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -a 53-55 -g F -p $(PATIENT_COUNT) -m EXM125-r4*
 
-calculate-patients-stu3:
-	mkdir -p stu3
-	cd stu3 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM125-FHIR3-7.2.000 -s $(MP_START) -e $(MP_END)
-
-calculate-patients-r4:
+calculate-patients:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM125-7.3.000 -s $(MP_START) -e $(MP_END)
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir $(MEASURE_DIR_OPTS) -s $(MP_START) -e $(MP_END) -t $(CALC_TYPE)

--- a/EXM_125-7.3.000/Makefile
+++ b/EXM_125-7.3.000/Makefile
@@ -16,7 +16,7 @@ ifeq ($(strip $(CALC_TYPE)),http)
 endif
 
 generate-patients:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_125-7.3.000/$(SYNTHEA_DIR)/ --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -a 53-55 -g F -p $(PATIENT_COUNT) -m EXM125-r4*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_125-7.3.000/$(SYNTHEA_DIR)/ --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -a 53-55 -g F -p $(PATIENT_COUNT) -m EXM125*
 
 calculate-patients:
 	mkdir -p r4

--- a/EXM_130-7.3.000/Makefile
+++ b/EXM_130-7.3.000/Makefile
@@ -16,7 +16,7 @@ ifeq ($(strip $(CALC_TYPE)),http)
 endif
 
 generate-patients:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_130-7.3.000/$(SYNTHEA_DIR)/ --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -a 51-61 --exporter.years_of_history=11 -p $(PATIENT_COUNT) -m EXM130-r4*
+	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_130-7.3.000/$(SYNTHEA_DIR)/ --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -a 51-61 --exporter.years_of_history=11 -p $(PATIENT_COUNT) -m EXM130*
 
 calculate-patients:
 	mkdir -p r4

--- a/EXM_130-7.3.000/Makefile
+++ b/EXM_130-7.3.000/Makefile
@@ -1,24 +1,23 @@
-all r4: info generate-patients-r4 calculate-patients-r4
-
-stu3: info generate-patients-stu3 calculate-patients-stu3
+all r4: info generate-patients calculate-patients
 
 info:
 	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 10
+CALC_TYPE := fqm
 MP_START := 2020-01-01
 MP_END := 2020-12-31
 
-generate-patients-stu3:
-	cd ../synthea && ./run_synthea --exporter.fhir.export=false --exporter.fhir_stu3.export=true --exporter.baseDirectory=../EXM_130-7.3.000/$(SYNTHEA_DIR)/ --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -a 51-51 -p $(PATIENT_COUNT) -m EXM130*
+ifeq ($(strip $(CALC_TYPE)),fqm)
+	MEASURE_DIR_OPTS := -b ../../connectathon/fhir401/bundles/measure/EXM130-7.3.000/EXM130-7.3.000-bundle.json
+endif
+ifeq ($(strip $(CALC_TYPE)),http)
+	MEASURE_DIR_OPTS := -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM130-7.3.000
+endif
 
-generate-patients-r4:
+generate-patients:
 	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_130-7.3.000/$(SYNTHEA_DIR)/ --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -a 51-61 --exporter.years_of_history=11 -p $(PATIENT_COUNT) -m EXM130-r4*
 
-calculate-patients-stu3:
-	mkdir -p stu3
-	cd stu3 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir_stu3 -u http://localhost:8080/cqf-ruler-dstu3/fhir -m measure-EXM130-FHIR3-7.2.000 -s $(MP_START) -e $(MP_END)
-
-calculate-patients-r4:
+calculate-patients:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM130-7.3.000 -s $(MP_START) -e $(MP_END)
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir $(MEASURE_DIR_OPTS) -s $(MP_START) -e $(MP_END) -t $(CALC_TYPE)

--- a/EXM_506-2.2.000/Makefile
+++ b/EXM_506-2.2.000/Makefile
@@ -1,17 +1,23 @@
-all r4: info generate-patients-r4 calculate-patients-r4
-
-stu3: info generate-patients-stu3 calculate-patients-stu3
+all r4: info generate-patients calculate-patients
 
 info:
 	$(info `make` will perform patient generation and calculation.)
 
 PATIENT_COUNT := 10
+CALC_TYPE := fqm
 MP_START := 2020-01-01
 MP_END := 2020-12-31
 
-generate-patients-r4:
+ifeq ($(strip $(CALC_TYPE)),fqm)
+	MEASURE_DIR_OPTS := -b ../../connectathon/fhir401/bundles/measure/EXM506-2.2.000/EXM506-2.2.000-bundle.json
+endif
+ifeq ($(strip $(CALC_TYPE)),http)
+	MEASURE_DIR_OPTS := -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM506-2.2.000
+endif
+
+generate-patients:
 	cd ../synthea && ./run_synthea --exporter.fhir.export=true --exporter.fhir_stu3.export=false --exporter.baseDirectory=../EXM_506-2.2.000/$(SYNTHEA_DIR)/ -p $(PATIENT_COUNT) --ecqm.measurementPeriodStart=$(MP_START)T00:00:00Z -m EXM506*
 
-calculate-patients-r4:
+calculate-patients:
 	mkdir -p r4
-	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir -u http://localhost:8080/cqf-ruler-r4/fhir -m measure-EXM506-2.2.000 -s $(MP_START) -e $(MP_END)
+	cd r4 && calculate-bundles -d ../$(SYNTHEA_DIR)/fhir $(MEASURE_DIR_OPTS) -s $(MP_START) -e $(MP_END) -t $(CALC_TYPE)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ define gen_calc_pts
 endef
 
 define load_all_pts
-	./load-cqf-ruler.sh $1 FHIR_VERSION=$2;
+	FHIR_VERSION=$2 ./load-cqf-ruler.sh $1;
 endef
 
 r4: .check-dependencies .setup-cqf-ruler-r4 synthea .copy-valuesets generate-patients-r4 calculate-patients-r4
@@ -53,7 +53,7 @@ connectathon:
 ifeq ($(BASE_DIR),connectathon)
 	$(info connectathon checks out a specific commit SHA in case filepaths are updated)
 	git clone https://github.com/DBCG/connectathon.git
-	cd connectathon && git checkout f8f42b3c1dfeaf8bfc70629632d9d92b8f657874
+	cd connectathon && git checkout 4be117b59939bb204711fea2018534ce0cb58c71
 endif
 
 VALUESET_FILES = $(shell find $(BASE_DIR)/fhir401/bundles -type f -name "valuesets*bundle.json")
@@ -69,73 +69,73 @@ VALUESET_FILES = $(shell find $(BASE_DIR)/fhir401/bundles -type f -name "valuese
 	# CMS 104
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM104-8.2.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM104-8.2.000/EXM104-8.2.000-files/measure-EXM104-8.2.000.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM104-8.2.000/EXM104-8.2.000-files/measure-EXM104-8.2.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM104-8.2.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM104-8.2.000/EXM104-8.2.000-files/library-EXM104-8.2.000.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM104-8.2.000/EXM104-8.2.000-files/library-EXM104-8.2.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM104-8.2.000/EXM104-8.2.000-files/library-deps-EXM104-8.2.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM104-8.2.000/EXM104-8.2.000-files/library-deps-EXM104-8.2.000-bundle.json
 	# CMS 105
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM105-8.2.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM105-8.2.000/EXM105-8.2.000-files/measure-EXM105-8.2.000.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM105-8.2.000/EXM105-8.2.000-files/measure-EXM105-8.2.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM105-8.2.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM105-8.2.000/EXM105-8.2.000-files/library-EXM105-8.2.000.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM105-8.2.000/EXM105-8.2.000-files/library-EXM105-8.2.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM105-8.2.000/EXM105-8.2.000-files/library-deps-EXM105-8.2.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM105-8.2.000/EXM105-8.2.000-files/library-deps-EXM105-8.2.000-bundle.json
 	# CMS 124
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM124-9.0.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM124-9.0.000/EXM124-9.0.000-files/measure-EXM124-9.0.000.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM124-9.0.000/EXM124-9.0.000-files/measure-EXM124-9.0.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM124-9.0.000/EXM124-9.0.000-files/library-deps-EXM124-9.0.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM124-9.0.000/EXM124-9.0.000-files/library-deps-EXM124-9.0.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM124-9.0.000 \
   		-H 'Content-Type: application/json' \
-		-d @./$(BASE_DIR)/fhir401/bundles/EXM124-9.0.000/EXM124-9.0.000-files/library-EXM124-9.0.000.json
+		-d @./$(BASE_DIR)/fhir401/bundles/measure/EXM124-9.0.000/EXM124-9.0.000-files/library-EXM124-9.0.000.json
 	# CMS 125
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM125-7.3.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM125-7.3.000/EXM125-7.3.000-files/measure-EXM125-7.3.000.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM125-7.3.000/EXM125-7.3.000-files/measure-EXM125-7.3.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM125-7.3.000/EXM125-7.3.000-files/library-deps-EXM125-7.3.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM125-7.3.000/EXM125-7.3.000-files/library-deps-EXM125-7.3.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM125-7.3.000 \
 		-H 'Content-Type: application/json' \
-		-d @./$(BASE_DIR)/fhir401/bundles/EXM125-7.3.000/EXM125-7.3.000-files/library-EXM125-7.3.000.json
+		-d @./$(BASE_DIR)/fhir401/bundles/measure/EXM125-7.3.000/EXM125-7.3.000-files/library-EXM125-7.3.000.json
 	# CMS 130
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM130-7.3.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM130-7.3.000/EXM130-7.3.000-files/measure-EXM130-7.3.000.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM130-7.3.000/EXM130-7.3.000-files/measure-EXM130-7.3.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM130-7.3.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM130-7.3.000/EXM130-7.3.000-files/library-EXM130-7.3.000.json 
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM130-7.3.000/EXM130-7.3.000-files/library-EXM130-7.3.000.json 
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir/ \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM130-7.3.000/EXM130-7.3.000-files/library-deps-EXM130-7.3.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM130-7.3.000/EXM130-7.3.000-files/library-deps-EXM130-7.3.000-bundle.json
 	# CMS 506
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM506-2.2.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM506-2.2.000/EXM506-2.2.000-files/measure-EXM506-2.2.000.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM506-2.2.000/EXM506-2.2.000-files/measure-EXM506-2.2.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM506-2.2.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM506-2.2.000/EXM506-2.2.000-files/library-EXM506-2.2.000.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM506-2.2.000/EXM506-2.2.000-files/library-EXM506-2.2.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir/ \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM506-2.2.000/EXM506-2.2.000-files/library-deps-EXM506-2.2.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM506-2.2.000/EXM506-2.2.000-files/library-deps-EXM506-2.2.000-bundle.json
 	# CMS 111
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM111-9.1.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM111-9.1.000/EXM111-9.1.000-files/measure-EXM111-9.1.000.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM111-9.1.000/EXM111-9.1.000-files/measure-EXM111-9.1.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Library/library-EXM111-9.1.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM111-9.1.000/EXM111-9.1.000-files/library-EXM111-9.1.000.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM111-9.1.000/EXM111-9.1.000-files/library-EXM111-9.1.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir/ \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM111-9.1.000/EXM111-9.1.000-files/library-deps-EXM111-9.1.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM111-9.1.000/EXM111-9.1.000-files/library-deps-EXM111-9.1.000-bundle.json
 	touch .seed-measures-r4
 
 
@@ -143,25 +143,25 @@ VALUESET_FILES = $(shell find $(BASE_DIR)/fhir401/bundles -type f -name "valuese
 	make .wait-cqf-ruler
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM104-8.2.000/EXM104-8.2.000-files/valuesets-EXM104-8.2.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM104-8.2.000/EXM104-8.2.000-files/valuesets-EXM104-8.2.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM105-8.2.000/EXM105-8.2.000-files/valuesets-EXM105-8.2.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM105-8.2.000/EXM105-8.2.000-files/valuesets-EXM105-8.2.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM124-9.0.000/EXM124-9.0.000-files/valuesets-EXM124-9.0.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM124-9.0.000/EXM124-9.0.000-files/valuesets-EXM124-9.0.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM125-7.3.000/EXM125-7.3.000-files/valuesets-EXM125-7.3.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM125-7.3.000/EXM125-7.3.000-files/valuesets-EXM125-7.3.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM130-7.3.000/EXM130-7.3.000-files/valuesets-EXM130-7.3.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM130-7.3.000/EXM130-7.3.000-files/valuesets-EXM130-7.3.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM506-2.2.000/EXM506-2.2.000-files/valuesets-EXM506-2.2.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM506-2.2.000/EXM506-2.2.000-files/valuesets-EXM506-2.2.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir401/bundles/EXM111-9.1.000/EXM111-9.1.000-files/valuesets-EXM111-9.1.000-bundle.json
+		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM111-9.1.000/EXM111-9.1.000-files/valuesets-EXM111-9.1.000-bundle.json
 	touch .seed-vs-r4
 
 
@@ -170,53 +170,53 @@ VALUESET_FILES = $(shell find $(BASE_DIR)/fhir401/bundles -type f -name "valuese
 	# EXM 104
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/EXM104_FHIR3-8.1.000/EXM104_FHIR3-8.1.000-files/library-deps-EXM104_FHIR3-8.1.000-bundle.json
+		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM104_FHIR3-8.1.000/EXM104_FHIR3-8.1.000-files/library-deps-EXM104_FHIR3-8.1.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Library/library-EXM104-FHIR3-8.1.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/EXM104_FHIR3-8.1.000/EXM104_FHIR3-8.1.000-files/library-EXM104_FHIR3-8.1.000.json
+		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM104_FHIR3-8.1.000/EXM104_FHIR3-8.1.000-files/library-EXM104_FHIR3-8.1.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM104-FHIR3-8.1.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/EXM104_FHIR3-8.1.000/EXM104_FHIR3-8.1.000-files/measure-EXM104_FHIR3-8.1.000.json
+		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM104_FHIR3-8.1.000/EXM104_FHIR3-8.1.000-files/measure-EXM104_FHIR3-8.1.000.json
 	# EXM 105
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/library-deps-EXM105_FHIR3-8.0.000-bundle.json
+		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/library-deps-EXM105_FHIR3-8.0.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Library/library-EXM105-FHIR3-8.0.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/library-EXM105_FHIR3-8.0.000.json
+		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/library-EXM105_FHIR3-8.0.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM105-FHIR3-8.0.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/measure-EXM105_FHIR3-8.0.000.json
+		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/measure-EXM105_FHIR3-8.0.000.json
 	# EXM 124
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-files/library-deps-EXM124_FHIR3-7.2.000-bundle.json
+		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-files/library-deps-EXM124_FHIR3-7.2.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Library/library-EXM124-FHIR3-7.2.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-files/library-EXM124_FHIR3-7.2.000.json
+		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-files/library-EXM124_FHIR3-7.2.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM124-FHIR3-7.2.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-files/measure-EXM124_FHIR3-7.2.000.json
+		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-files/measure-EXM124_FHIR3-7.2.000.json
 	# EXM 125
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-files/library-deps-EXM125_FHIR3-7.2.000-bundle.json
+		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-files/library-deps-EXM125_FHIR3-7.2.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Library/library-EXM125-FHIR3-7.2.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-files/library-EXM125_FHIR3-7.2.000.json
+		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-files/library-EXM125_FHIR3-7.2.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM125-FHIR3-7.2.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-files/measure-EXM125_FHIR3-7.2.000.json
+		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-files/measure-EXM125_FHIR3-7.2.000.json
 	# EXM 130
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/library-deps-EXM130_FHIR3-7.2.000-bundle.json
+		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/library-deps-EXM130_FHIR3-7.2.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Library/library-EXM130-FHIR3-7.2.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/library-EXM130_FHIR3-7.2.000.json
+		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/library-EXM130_FHIR3-7.2.000.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM130-FHIR3-7.2.000 \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/measure-EXM130_FHIR3-7.2.000.json
+		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/measure-EXM130_FHIR3-7.2.000.json
 	touch .seed-measures-stu3
 	
 .seed-vs-stu3:
@@ -224,19 +224,19 @@ VALUESET_FILES = $(shell find $(BASE_DIR)/fhir401/bundles -type f -name "valuese
 	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/EXM104_FHIR3-8.1.000/EXM104_FHIR3-8.1.000-files/valuesets-EXM104_FHIR3-8.1.000-bundle.json
+		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM104_FHIR3-8.1.000/EXM104_FHIR3-8.1.000-files/valuesets-EXM104_FHIR3-8.1.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/valuesets-EXM105_FHIR3-8.0.000-bundle.json
+		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/valuesets-EXM105_FHIR3-8.0.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-files/valuesets-EXM124_FHIR3-7.2.000-bundle.json
+		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-files/valuesets-EXM124_FHIR3-7.2.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
 		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-files/valuesets-EXM125_FHIR3-7.2.000-bundle.json
+		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-files/valuesets-EXM125_FHIR3-7.2.000-bundle.json
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
 		-H 'Content-Type: application/json' \
-0		-d @$(BASE_DIR)/fhir3/bundles/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/valuesets-EXM130_FHIR3-7.2.000-bundle.json
+0		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/valuesets-EXM130_FHIR3-7.2.000-bundle.json
 	touch .seed-vs-stu3
 
 synthea:

--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,6 @@ preload: clean .new-cqf-ruler connectathon .seed-measures .run-load-script
 
 clean:
 	-docker stop cqf-ruler
-	-rm -rf synthea
 	-rm -rf EXM_*/synthea_output
 	-rm .setup-cqf-ruler-stu3
 	-rm .setup-cqf-ruler-r4
@@ -186,5 +185,9 @@ clean:
 	-rm .seed-vs-r4
 	-rm .seed-vs
 	-rm .copy-valuesets
+
+deep-clean: clean
+	-rm -rf synthea
+	-rm -rf connectathon
 
 .PHONY: all clean info .wait-cqf-ruler

--- a/Makefile
+++ b/Makefile
@@ -13,36 +13,25 @@ define gen_calc_pts
 endef
 
 define load_all_pts
-	FHIR_VERSION=$2 ./load-cqf-ruler.sh $1;
+	./load-cqf-ruler.sh $1;
 endef
 
-r4: .check-dependencies .setup-cqf-ruler-r4 synthea .copy-valuesets generate-patients-r4 calculate-patients-r4
+r4: .check-dependencies .setup-cqf-ruler synthea .copy-valuesets generate-patients calculate-patients
 
-stu3: .check-dependencies .setup-cqf-ruler-stu3 synthea generate-patients-stu3 calculate-patients-stu3
+all all-r4: .check-dependencies .setup-cqf-ruler synthea
+	$(foreach dir,$(MEASURE_DIRS),$(call gen_calc_pts,$(dir)))
 
-all all-r4: .check-dependencies .setup-cqf-ruler-r4 synthea
-	$(foreach dir,$(MEASURE_DIRS),$(call gen_calc_pts,$(dir),r4))
-
-all-stu3: .check-dependencies .setup-cqf-ruler-stu3 synthea
-	$(foreach dir,$(MEASURE_DIRS),$(call gen_calc_pts,$(dir),stu3))
-
-preload-all preload-all-r4: clean .setup-cqf-ruler-r4 .wait-cqf-ruler
-	$(foreach dir,$(MEASURE_DIRS),$(call load_all_pts,$(dir),r4))
-
-preload-all-stu3: clean .setup-cqf-ruler-stu3 .wait-cqf-ruler
-	$(foreach dir,$(MEASURE_DIRS),$(call load_all_pts,$(dir),stu3))
+preload-all: clean .setup-cqf-ruler .wait-cqf-ruler
+	$(foreach dir,$(MEASURE_DIRS),$(call load_all_pts,$(dir)))
 
 info:
-	$(info usage: `make MEASURE_DIR=/path/to/measure/dir VERSION=x.y.z)
+	$(info usage: `make MEASURE_DIR=/path/to/measure/dir VERSION=x.y.z CALC_TYPE=<fqm/http>`)
 
 .check-dependencies:
 	npm install -g fhir-bundle-calculator
 
-.setup-cqf-ruler-stu3: .new-cqf-ruler connectathon .seed-measures-stu3 .seed-vs-stu3
-	touch .setup-cqf-ruler-stu3
-
-.setup-cqf-ruler-r4: .new-cqf-ruler connectathon .seed-measures-r4 .seed-vs-r4
-	touch .setup-cqf-ruler-r4
+.setup-cqf-ruler: .new-cqf-ruler connectathon .seed-measures .seed-vs
+	touch .setup-cqf-ruler
 
 .new-cqf-ruler:
 	docker pull contentgroup/cqf-ruler:develop
@@ -64,7 +53,7 @@ VALUESET_FILES = $(shell find $(BASE_DIR)/fhir401/bundles -type f -name "valuese
 .wait-cqf-ruler:
 	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-r4`; do printf '.'; sleep 5; done
 
-.seed-measures-r4:
+.seed-measures:
 	make .wait-cqf-ruler
 	# CMS 104
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-r4/fhir/Measure/measure-EXM104-8.2.000 \
@@ -136,10 +125,9 @@ VALUESET_FILES = $(shell find $(BASE_DIR)/fhir401/bundles -type f -name "valuese
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir/ \
 		-H 'Content-Type: application/json' \
 		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM111-9.1.000/EXM111-9.1.000-files/library-deps-EXM111-9.1.000-bundle.json
-	touch .seed-measures-r4
+	touch .seed-measures
 
-
-.seed-vs-r4:
+.seed-vs:
 	make .wait-cqf-ruler
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
@@ -162,107 +150,22 @@ VALUESET_FILES = $(shell find $(BASE_DIR)/fhir401/bundles -type f -name "valuese
 	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-r4/fhir \
 		-H 'Content-Type: application/json' \
 		-d @$(BASE_DIR)/fhir401/bundles/measure/EXM111-9.1.000/EXM111-9.1.000-files/valuesets-EXM111-9.1.000-bundle.json
-	touch .seed-vs-r4
-
-
-.seed-measures-stu3:
-	make .wait-cqf-ruler
-	# EXM 104
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
-		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM104_FHIR3-8.1.000/EXM104_FHIR3-8.1.000-files/library-deps-EXM104_FHIR3-8.1.000-bundle.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Library/library-EXM104-FHIR3-8.1.000 \
-		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM104_FHIR3-8.1.000/EXM104_FHIR3-8.1.000-files/library-EXM104_FHIR3-8.1.000.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM104-FHIR3-8.1.000 \
-		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM104_FHIR3-8.1.000/EXM104_FHIR3-8.1.000-files/measure-EXM104_FHIR3-8.1.000.json
-	# EXM 105
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
-		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/library-deps-EXM105_FHIR3-8.0.000-bundle.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Library/library-EXM105-FHIR3-8.0.000 \
-		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/library-EXM105_FHIR3-8.0.000.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM105-FHIR3-8.0.000 \
-		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/measure-EXM105_FHIR3-8.0.000.json
-	# EXM 124
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
-		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-files/library-deps-EXM124_FHIR3-7.2.000-bundle.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Library/library-EXM124-FHIR3-7.2.000 \
-		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-files/library-EXM124_FHIR3-7.2.000.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM124-FHIR3-7.2.000 \
-		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-files/measure-EXM124_FHIR3-7.2.000.json
-	# EXM 125
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
-		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-files/library-deps-EXM125_FHIR3-7.2.000-bundle.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Library/library-EXM125-FHIR3-7.2.000 \
-		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-files/library-EXM125_FHIR3-7.2.000.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM125-FHIR3-7.2.000 \
-		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-files/measure-EXM125_FHIR3-7.2.000.json
-	# EXM 130
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
-		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/library-deps-EXM130_FHIR3-7.2.000-bundle.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Library/library-EXM130-FHIR3-7.2.000 \
-		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/library-EXM130_FHIR3-7.2.000.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X PUT http://localhost:8080/cqf-ruler-dstu3/fhir/Measure/measure-EXM130-FHIR3-7.2.000 \
-		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/measure-EXM130_FHIR3-7.2.000.json
-	touch .seed-measures-stu3
-	
-.seed-vs-stu3:
-	make .wait-cqf-ruler
-	until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-dstu3`; do printf '.'; sleep 5; done
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
-		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM104_FHIR3-8.1.000/EXM104_FHIR3-8.1.000-files/valuesets-EXM104_FHIR3-8.1.000-bundle.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
-		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM105_FHIR3-8.0.000/EXM105_FHIR3-8.0.000-files/valuesets-EXM105_FHIR3-8.0.000-bundle.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
-		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM124_FHIR3-7.2.000/EXM124_FHIR3-7.2.000-files/valuesets-EXM124_FHIR3-7.2.000-bundle.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
-		-H 'Content-Type: application/json' \
-		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM125_FHIR3-7.2.000/EXM125_FHIR3-7.2.000-files/valuesets-EXM125_FHIR3-7.2.000-bundle.json
-	curl -s -o /dev/null -w "Response Code: %{http_code}\n" -X POST http://localhost:8080/cqf-ruler-dstu3/fhir \
-		-H 'Content-Type: application/json' \
-0		-d @$(BASE_DIR)/fhir3/bundles/measure/EXM130_FHIR3-7.2.000/EXM130_FHIR3-7.2.000-files/valuesets-EXM130_FHIR3-7.2.000-bundle.json
-	touch .seed-vs-stu3
+	touch .seed-vs
 
 synthea:
 	git clone --single-branch --branch abacus https://github.com/projecttacoma/synthea.git
 
 PATIENT_COUNT := 10
-generate-patients-stu3:
-	make -C $(MEASURE_DIR) generate-patients-stu3
+CALC_TYPE := fqm
+generate-patients:
+	make -C $(MEASURE_DIR) generate-patients
 
-calculate-patients-stu3:
-	make -C $(MEASURE_DIR) calculate-patients-stu3
+calculate-patients:
+	make -C $(MEASURE_DIR) calculate-patients
 
-generate-patients-r4:
-	make -C $(MEASURE_DIR) generate-patients-r4
+preload: clean .new-cqf-ruler connectathon .seed-measures .run-load-script
 
-calculate-patients-r4:
-	make -C $(MEASURE_DIR) calculate-patients-r4
-
-preload-stu3: clean .new-cqf-ruler connectathon .seed-measures-stu3 .run-load-script-stu3
-
-preload-r4: clean .new-cqf-ruler connectathon .seed-measures-r4 .run-load-script-r4
-
-.run-load-script-stu3: .wait-cqf-ruler
-	FHIR_VERSION=stu3 ./load-cqf-ruler.sh $(MEASURE_DIR)
-
-.run-load-script-r4: .wait-cqf-ruler
+.run-load-script: .wait-cqf-ruler
 	./load-cqf-ruler.sh $(MEASURE_DIR) FHIR_VERSION=r4
 
 .update-cqf-ruler-image:
@@ -274,11 +177,14 @@ clean:
 	-rm -rf EXM_*/synthea_output
 	-rm .setup-cqf-ruler-stu3
 	-rm .setup-cqf-ruler-r4
+	-rm .setup-cqf-ruler
 	-rm .new-cqf-ruler
 	-rm .seed-measures-stu3
 	-rm .seed-measures-r4
+	-rm .seed-measures
 	-rm .seed-vs-stu3
 	-rm .seed-vs-r4
+	-rm .seed-vs
 	-rm .copy-valuesets
 
 .PHONY: all clean info .wait-cqf-ruler

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ A tool for generating eCQM-specific patient data using [Synthea&trade;](https://
 
 ## Developer Quickstart
 
-**NOTE**: This tool is only compatible with `fhir-bundle-calculator` version 3.0.0 or higher:
+**NOTE**: This tool is only compatible with `fhir-bundle-calculator` version 4.0.0 or higher:
 
 ``` bash
 npm install -g fhir-bundle-calculator
 calculate-bundles --version
-# should ouput 3.x.x
+# should ouput 4.x.x
 ```
 
 ### Installation
@@ -40,13 +40,13 @@ cd fhir-patient-generator
 #### As a CI tool in the connectathon repository
 
 ```
-make MEAUSRE_DIR/path/to/measure/dir <r4|stu3> CI_TOOL=true
+make MEAUSRE_DIR/path/to/measure/dir CI_TOOL=true
 ```
 
 #### Running Standalone
 
 ```
-make MEASURE_DIR=/path/to/measure/dir <r4|stu3>
+make MEASURE_DIR=/path/to/measure/dir CALC_TYPE=<fqm|http> PATIENT_COUNT=10
 ```
 
 `MEASURE_DIR` is the relative path to the directory in `fhir-patient-generator` for the desired measure. Currently supported measures:
@@ -57,14 +57,15 @@ make MEASURE_DIR=/path/to/measure/dir <r4|stu3>
 * EXM_125
 * EXM_130
 
+`CALC_TYPE` tells `fhir-bundle-calculator` which engine to use for measure calculation. The default is `fqm-execution`, which is also what will be used if `CALC_TYPE=fqm` is specified. To use `cqf-ruler` instead, specify `CALC_TYPE=http` after the `make` command.
+
+`PATIENT_COUNT` specifies the number of (live) Synthea patients to generate for each measure. Actual patient counts will vary because Synthea doesn't count dead patients during generation.
+
 #### Examples
 
 ``` bash
 # Generate R4 patient data for EXM130
-make MEASURE_DIR=EXM_130 r4
-
-# Generate stu3 patient data for EXM130
-make MEASURE_DIR=EXM_130 stu3
+make MEASURE_DIR=EXM_130
 ```
 
 ## Generation and Calculation
@@ -75,6 +76,7 @@ The `Makefile` in `fhir-patient-generator` consolidates the following dependenci
 * [cqf-ruler](https://github.com/DBCG/cqf-ruler): Used for running calculation and getting MeasureReport resources
 * [Connectathon repository](https://github.com/DBCG/connectathon): Used for loading cqf-ruler with needed ValueSet, Library, and Measure resources
 * [fhir-bundle-calculator](https://github.com/projecttacoma/fhir-bundle-calculator): Command line utility for requesting and interpreting calculation results
+* [fqm-execution](https://github.com/projecttacoma/fqm-execution): Command line utility/Typescript library for calculating FHIR-based eCQMs against FHIR-based patients
 
 The following diagram depicts the operations that each utility is responsible for and the order in which they are executed:
 
@@ -89,7 +91,7 @@ We have published patient data for all supported measures in both `R4` and `STU3
 `fhir-patient-generator` also supports loading and tagging a Docker image with patient data for a specific measure, not including ValueSets. This image will be published to the [Tacoma Docker organization](https://hub.docker.com/r/tacoma/cqf-ruler-preloaded/tags)
 
 ```
-make MEASURE_DIR=/path/to/measure/dir VERSION=x.y.z preload-<r4|stu3>
+make MEASURE_DIR=/path/to/measure/dir VERSION=x.y.z preload
 ```
 
 This command will tag and push `tacoma/cqf-ruler-preloaded:x.y.z` to Dockerhub.
@@ -98,8 +100,5 @@ This command will tag and push `tacoma/cqf-ruler-preloaded:x.y.z` to Dockerhub.
 
 ``` bash
 # Publish preloaded image with EXM130 R4 data under tag 1.0.0
-make MEASURE_DIR=EXM_130 VERSION=1.0.0 preload-r4
-
-# Publish preloaded image with EXM130 STU3 data under tag 1.0.0
-make MEASURE_DIR=EXM_130 VERSION=1.0.0 preload-stu3
+make MEASURE_DIR=EXM_130 VERSION=1.0.0 preload
 ```

--- a/load-cqf-ruler.sh
+++ b/load-cqf-ruler.sh
@@ -9,18 +9,11 @@ fi
 cd $1
 
 BASE_URL="http://localhost:8080/cqf-ruler-r4/fhir"
-
-if [ $FHIR_VERSION == "stu3" ]
-then
-    BASE_URL="http://localhost:8080/cqf-ruler-dstu3/fhir"
-    OUTPUT_DIR="stu3"
-else
-    OUTPUT_DIR="r4"
-fi
+OUTPUT_DIR="patients-r4"
 
 # In the event that there are multiple results output folders,
 # just use the most recent one
-OUTPUT_DIR="$OUTPUT_DIR/output/$(ls -t $OUTPUT_DIR/output | head -1)"
+# OUTPUT_DIR="$OUTPUT_DIR/output/$(ls -t $OUTPUT_DIR/output | head -1)"
 echo "Using directory $OUTPUT_DIR"
 
 check_success() {
@@ -31,7 +24,7 @@ check_success() {
   fi
 }
 
-curl -s -o /dev/null -w "%{http_code}\n" -X POST -H "Content-Type: application/json" --data @$OUTPUT_DIR/measure-report.json "$BASE_URL/MeasureReport"
+curl -s -o /dev/null -w "%{http_code}\n" -X POST -H "Content-Type: application/json" --data @$OUTPUT_DIR/population-measure-report.json "$BASE_URL/MeasureReport"
 check_success
 
 echo 'Posting ipop patients for:' "$OUTPUT_DIR"

--- a/release-docker-image.sh
+++ b/release-docker-image.sh
@@ -7,7 +7,7 @@ then
 fi
 
 # 1 if grep found a match (no ValueSets), 0 otherwise
-VSET_SEARCH_MATCH=`curl -s http://localhost:8080/cqf-ruler-dstu3/fhir/ValueSet | grep -wc "\"total\":\s0"`
+VSET_SEARCH_MATCH=`curl -s http://localhost:8080/cqf-ruler-r4/fhir/ValueSet | grep -wc "\"total\":\s0"`
 if [ $VSET_SEARCH_MATCH -eq 1 ]
 then
     docker tag `docker commit cqf-ruler` tacoma/cqf-ruler-preloaded:$1


### PR DESCRIPTION
# Summary
This PR updates `fhir-patient-generator` to add a couple of features:
* Updates the `connectathon` repo to a newer SHA
* Removes `Makefile` support for STU3
  ** Keeps `patients-stu3` folders with existing generated patients
* Adds support for a `CALC_TYPE` option for choosing which calculation type to use:
  ** `fqm` (default): use `fqm-execution`
  ** `http`: use `cqf-ruler`

NOTE: `cqf-ruler` dependencies are still run no matter which `CALC_TYPE` is specified, because of the amount of optimization that would be required to only run them for `http` calculation. The bulk of these deps are only relevant on the first run, and `fqm` calculation is still much faster.

NOTE: `fqm-execution` does not appear to support population-level Measure Report generation through `fhir-bundle-calculator`

## New behavior
By default, `fhir-patient-generator` calculates using `fqm-execution` now, which provides orders-of-magnitude better performance than `cqf-ruler`.

## Code changes
* Removed `STU3` Makefile tasks
* Added a `CALC_TYPE` variable, which defaults to `fqm`, which is used by the measure Makefiles to decide which options to pass to `calculate-bundles`

# Testing guidance
* `make all CALC_TYPE=fqm` will generate 10 patients per measure using `fqm-execution`. Ensure that all measures properly create patients and calculate
* `make all CALC_TYPE=http` will generate 10 patients per measure using `cqf-ruler`. Ensure that all measures properly create patients and calculate
