### PR TITLE
Update Synthea branch, and CQF-ruler tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ info:
 	touch .setup-cqf-ruler
 
 .new-cqf-ruler:
-	docker pull contentgroup/cqf-ruler:develop
-	docker run --name cqf-ruler --rm -dit -p 8080:8080 contentgroup/cqf-ruler:develop
+	docker pull contentgroup/cqf-ruler:latest
+	docker run --name cqf-ruler --rm -dit -p 8080:8080 contentgroup/cqf-ruler:latest
 	touch .new-cqf-ruler
 
 connectathon:
@@ -153,7 +153,7 @@ VALUESET_FILES = $(shell find $(BASE_DIR)/fhir401/bundles -type f -name "valuese
 	touch .seed-vs
 
 synthea:
-	git clone --single-branch --branch abacus https://github.com/projecttacoma/synthea.git
+	git clone --single-branch --branch abacus-dev https://github.com/projecttacoma/synthea.git
 
 PATIENT_COUNT := 10
 CALC_TYPE := fqm


### PR DESCRIPTION
# Summary
FPG now uses the `abacus-dev` branch of synthea to generate patients

FPG now uses the `latest` tag of cqf-ruler to run calculations (if cqf-ruler is selected).

## New behavior
## Code changes
# Testing guidance
Delete the synthea repository in FPG by running `make deep-clean`

Test calculation using any of the `make` commands. One option is `make all-r4`.
